### PR TITLE
Override getName method

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/capability/server/ServerTemplateProcessing.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/server/ServerTemplateProcessing.java
@@ -62,6 +62,11 @@ public class ServerTemplateProcessing implements ITemplateProcessing {
 		}
 
 		@Override
+		public String getName() {
+			return template.getName();
+		}
+
+		@Override
 		public String getNamespace(){
 			return namespace;
 		}


### PR DESCRIPTION
If this is not done and there is an error creating the resource on server, NPE is thrown.