### PR TITLE
Make default jar output location configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		
 		<!-- integration test properties file -->
 		<integrationtest.properties>${basedir}/src/test/resources/integrationTest.properties</integrationtest.properties>
-
+		<jar.outputDir>${project.build.directory}</jar.outputDir>
 	</properties>
 
 	<!-- Issues -->
@@ -100,6 +100,9 @@
 				<plugin>
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>2.4</version>
+					<configuration>
+					  <outputDirectory>${jar.outputDir}</outputDirectory>
+					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
With the new jar.outputDir property, one can now automatically generate the rest client jar
directly in the Eclipse org.jboss.tools.openshift.client/lib folder

- Right-click on the openshift-rest-client-java project
- Run As > Maven Build
- set goals=package
- add jar.outpuDir property, set the absolute path to org.jboss.tools.openshift.client/lib as value
- In the refresh tab, enable refresh resources upon completion
- click specify resources..., select org.jboss.tools.openshift.client/lib

Run, profit!

Signed-off-by: Fred Bricon <fbricon@gmail.com>