### PR TITLE
Add Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 OpenShift Java REST Client
 ===========================
 
-[![Travis](https://travis-ci.org/openshift/openshift-restclient-java.svg?branch=master)](https://travis-ci.org/openshift/openshift-restclient-java)
+[![Travis](https://travis-ci.org/openshift/openshift-restclient-java.svg?branch=master)](https://travis-ci.org/openshift/openshift-restclient-java) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.openshift/openshift-restclient-java/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.openshift/openshift-restclient-java)
 
 This is the Java REST client for the version 3 architecture of [OpenShift](https://github.com/openshift/origin) based on Kubernetes.  The implementation is
 a work in progress to provide functionality and features of the command-line interface and is used by JBoss Tools for OpenShift.  For compatibility with


### PR DESCRIPTION
Add Maven Central badge which displayes the current client version and makes it easier to get (just after a click) a ready to copy-paste code snippet to put into Maven/Gradle/Sbt/other build configuration file.