### PR TITLE
Add setTagWithImagId function into ImageStream model

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/model/ImageStream.java
+++ b/src/main/java/com/openshift/internal/restclient/model/ImageStream.java
@@ -82,6 +82,18 @@ public class ImageStream extends KubernetesResource implements IImageStream {
 		tags.add(tag);
 	}
 	
+	@Override
+	public void setTagWithImageId(String newTag, String fromImageId) {
+		ModelNode tags = get(SPEC_TAGS);
+		ModelNode tag = new ModelNode();
+		tag.get("name").set(newTag);
+		ModelNode from = new ModelNode();
+		from.get("kind").set("ImageStreamImage");
+		from.get("name").set(fromImageId);
+		tag.get("from").set(from);
+		tags.add(tag);
+	}
+	
 	protected String getImageId(List<ModelNode> itemWrappers) {
 		for (ModelNode itemWrapper : itemWrappers) {
 			ModelNode image = itemWrapper.get(IMAGE);

--- a/src/main/java/com/openshift/restclient/model/IImageStream.java
+++ b/src/main/java/com/openshift/restclient/model/IImageStream.java
@@ -35,8 +35,17 @@ public interface IImageStream extends IResource{
 	 */
 	void setTag(String newTag, String fromTag);
 	
+	
 	/**
-	 * Gets the long imagae id for the provided tag
+	 * Set a new tag related to a docker image
+	 * 
+	 * @param newTag the new tag to create
+	 * @param imageId image id of the tag image
+	 */
+	void setTagWithImageId(String newTag, String fromImageId );
+	
+	/**
+	 * Gets the long image id for the provided tag
 	 * @param tagName   name of the image stream tag to interrogate
 	 * @return
 	 */


### PR DESCRIPTION
Hi folks, this PR adds the feature to tag an image into an imageStream using a reference to a image name. It behaves like the tag process using OpenShift CLI.