### PR TITLE
[JBIDE-21626] Add ImageStreamImport Capability

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/DefaultClient.java
+++ b/src/main/java/com/openshift/internal/restclient/DefaultClient.java
@@ -415,6 +415,7 @@ public class DefaultClient implements IClient, IHttpConstants{
 			typeMappings.put(ResourceKind.DEPLOYMENT_CONFIG, osEndpoint);
 			typeMappings.put(ResourceKind.IMAGE_STREAM, osEndpoint);
 			typeMappings.put(ResourceKind.IMAGE_STREAM_TAG, osEndpoint);
+			typeMappings.put(ResourceKind.IMAGE_STREAM_IMPORT, osEndpoint);
 			typeMappings.put(ResourceKind.OAUTH_ACCESS_TOKEN, osEndpoint);
 			typeMappings.put(ResourceKind.OAUTH_AUTHORIZE_TOKEN, osEndpoint);
 			typeMappings.put(ResourceKind.OAUTH_CLIENT, osEndpoint);

--- a/src/main/java/com/openshift/internal/restclient/ResourceFactory.java
+++ b/src/main/java/com/openshift/internal/restclient/ResourceFactory.java
@@ -45,6 +45,7 @@ import com.openshift.internal.restclient.model.authorization.OpenshiftRole;
 import com.openshift.internal.restclient.model.authorization.PolicyBinding;
 import com.openshift.internal.restclient.model.authorization.RoleBinding;
 import com.openshift.internal.restclient.model.build.BuildRequest;
+import com.openshift.internal.restclient.model.image.ImageStreamImport;
 import com.openshift.internal.restclient.model.oauth.OAuthAccessToken;
 import com.openshift.internal.restclient.model.oauth.OAuthAuthorizeToken;
 import com.openshift.internal.restclient.model.oauth.OAuthClient;
@@ -79,6 +80,7 @@ public class ResourceFactory implements IResourceFactory{
 		IMPL_MAP.put(ResourceKind.CONFIG, Config.class);
 		IMPL_MAP.put(ResourceKind.DEPLOYMENT_CONFIG, DeploymentConfig.class);
 		IMPL_MAP.put(ResourceKind.IMAGE_STREAM, ImageStream.class);
+		IMPL_MAP.put(ResourceKind.IMAGE_STREAM_IMPORT, ImageStreamImport.class);
 		IMPL_MAP.put(ResourceKind.LIST, com.openshift.internal.restclient.model.List.class);
 		IMPL_MAP.put(ResourceKind.OAUTH_ACCESS_TOKEN, OAuthAccessToken.class);
 		IMPL_MAP.put(ResourceKind.OAUTH_AUTHORIZE_TOKEN, OAuthAuthorizeToken.class);

--- a/src/main/java/com/openshift/internal/restclient/capability/CapabilityInitializer.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/CapabilityInitializer.java
@@ -16,6 +16,7 @@ import com.openshift.internal.restclient.capability.resources.ClientCapability;
 import com.openshift.internal.restclient.capability.resources.DeployCapability;
 import com.openshift.internal.restclient.capability.resources.DeploymentConfigTraceability;
 import com.openshift.internal.restclient.capability.resources.DeploymentTraceability;
+import com.openshift.internal.restclient.capability.resources.ImageStreamImportCapability;
 import com.openshift.internal.restclient.capability.resources.OpenShiftBinaryPodLogRetrieval;
 import com.openshift.internal.restclient.capability.resources.OpenShiftBinaryPortForwarding;
 import com.openshift.internal.restclient.capability.resources.OpenShiftBinaryRSync;
@@ -34,6 +35,7 @@ import com.openshift.restclient.capability.resources.IClientCapability;
 import com.openshift.restclient.capability.resources.IDeployCapability;
 import com.openshift.restclient.capability.resources.IDeploymentConfigTraceability;
 import com.openshift.restclient.capability.resources.IDeploymentTraceability;
+import com.openshift.restclient.capability.resources.IImageStreamImportCapability;
 import com.openshift.restclient.capability.resources.IPodLogRetrieval;
 import com.openshift.restclient.capability.resources.IPortForwardable;
 import com.openshift.restclient.capability.resources.IProjectTemplateList;
@@ -108,6 +110,7 @@ public class CapabilityInitializer {
 	public static void initializeCapabilities(Map<Class<? extends ICapability>, ICapability> capabilities, IProject project, IClient client){
 		initializeCapability(capabilities, IProjectTemplateProcessing.class, new ProjectTemplateProcessing(project, client));
 		initializeCapability(capabilities, IProjectTemplateList.class, new ProjectTemplateListCapability(project, client));
+		initializeCapability(capabilities, IImageStreamImportCapability.class, new ImageStreamImportCapability(project, client));
 	}
 	
 	public static  void initializeCapabilities(Map<Class<? extends ICapability>, ICapability> capabilities, Service service, IClient client){

--- a/src/main/java/com/openshift/internal/restclient/capability/resources/DeployCapability.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/resources/DeployCapability.java
@@ -55,11 +55,11 @@ public class DeployCapability implements IDeployCapability{
 	public void deploy() {
 		try {
 			final String deploymentName = getLatestDeploymentName();
-			LOG.debug("Attempting to deploy latest deployment for config '%s'.  Loading deployment: '%s'", config.getName(), deploymentName);
+			LOG.debug("Attempting to deploy latest deployment for config %s.  Loading deployment: %s", config.getName(), deploymentName);
 			IReplicationController deployment = client.get(ResourceKind.REPLICATION_CONTROLLER, deploymentName, config.getNamespace());
 			final String status = getStatusFor(deployment);
 			if(!COMPLETED_STATES.contains(status)) {
-				LOG.debug("Skipping deployment because deployment status '%s' for '%s' is not in %s", new Object [] {status, deploymentName, COMPLETED_STATES});
+				LOG.debug("Skipping deployment because deployment status %s for %s is not in %s", new Object [] {status, deploymentName, COMPLETED_STATES});
 				return;
 			}
 		}catch(OpenShiftException e) {

--- a/src/main/java/com/openshift/internal/restclient/capability/resources/ImageStreamImportCapability.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/resources/ImageStreamImportCapability.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.capability.resources;
+
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.capability.resources.IImageStreamImportCapability;
+import com.openshift.restclient.images.DockerImageURI;
+import com.openshift.restclient.model.IProject;
+import com.openshift.restclient.model.image.IImageStreamImport;
+
+/**
+ * 
+ * @author jeff.cantrill
+ *
+ */
+public class ImageStreamImportCapability implements IImageStreamImportCapability {
+
+	private IClient client;
+	private IProject project;
+
+	public ImageStreamImportCapability(IProject project, IClient client) {
+		this.project = project;
+		this.client = client;
+	}
+	
+	@Override
+	public IImageStreamImport importImageMetadata(DockerImageURI uri) {
+		
+		IImageStreamImport streamImport = client.getResourceFactory().stub(ResourceKind.IMAGE_STREAM_IMPORT, "jbosstools-openshift-deployimage", project.getName());
+		streamImport.setImport(false);
+		streamImport.addImage("DockerImage", uri);
+		return client.create(streamImport);
+	}
+
+
+	@Override
+	public boolean isSupported() {
+		return true;
+	}
+
+	@Override
+	public String getName() {
+		return ImageStreamImportCapability.class.getSimpleName();
+	}
+
+}

--- a/src/main/java/com/openshift/internal/restclient/model/ImageStream.java
+++ b/src/main/java/com/openshift/internal/restclient/model/ImageStream.java
@@ -28,7 +28,7 @@ import com.openshift.restclient.model.image.ITagReference;
  */
 public class ImageStream extends KubernetesResource implements IImageStream {
 
-	private static final String DOCKER_IMAGE_REPO = "status.dockerImageRepository";
+	private static final String DOCKER_IMAGE_REPO = "spec.dockerImageRepository";
 	private static final String SPEC_TAGS = "spec.tags";
 	private static final String STATUS_TAGS = "status.tags";
 	private static final String TAG = "tag";
@@ -44,17 +44,21 @@ public class ImageStream extends KubernetesResource implements IImageStream {
 		super(node, client, propertyKeys);
 		this.propertyKeys = propertyKeys;
 	}
-
+	
 	@Override
 	public void setDockerImageRepository(DockerImageURI uri) {
-		set(DOCKER_IMAGE_REPO, uri.getAbsoluteUri());		
+		setDockerImageRepository(uri.getAbsoluteUri());		
+	}
+
+	@Override
+	public void setDockerImageRepository(String uri) {
+		set(DOCKER_IMAGE_REPO, uri);		
 	}
 
 	@Override
 	public DockerImageURI getDockerImageRepository() {
 		return new DockerImageURI(asString(DOCKER_IMAGE_REPO));
 	}
-
 	
 	@Override
 	public Collection<String> getTagNames() {

--- a/src/main/java/com/openshift/internal/restclient/model/KubernetesResource.java
+++ b/src/main/java/com/openshift/internal/restclient/model/KubernetesResource.java
@@ -125,6 +125,10 @@ public class KubernetesResource implements IResource, ResourcePropertyKeys {
 		return annotations.containsKey(key);
 	}
 	
+	protected Map<String, String []> getPropertyKeys(){
+		return this.propertyKeys;
+	}
+	
 	public IClient getClient(){
 		return client;
 	}

--- a/src/main/java/com/openshift/internal/restclient/model/image/ImageStreamImport.java
+++ b/src/main/java/com/openshift/internal/restclient/model/image/ImageStreamImport.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.model.image;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jboss.dmr.ModelNode;
+
+import com.openshift.internal.restclient.model.KubernetesResource;
+import com.openshift.internal.restclient.model.Status;
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.images.DockerImageURI;
+import com.openshift.restclient.model.IStatus;
+import com.openshift.restclient.model.image.IImageStreamImport;
+
+/**
+ * 
+ * @author jeff.cantrill
+ *
+ */
+public class ImageStreamImport extends KubernetesResource implements IImageStreamImport {
+
+	private static final String IMAGE_DOCKER_IMAGE_REFERENCE = "image.dockerImageReference";
+	private static final String STATUS = "status";
+	private static final String STATUS_IMAGES = "status.images";
+	private static final String FROM_KIND = "from.kind";
+	private static final String SPEC_IMAGES = "spec.images";
+	private static final String SPEC_IMPORT = "spec.import";
+
+	public ImageStreamImport(ModelNode node, IClient client, Map<String, String[]> overrideProperties) {
+		super(node, client, overrideProperties);
+	}
+
+	@Override
+	public void setImport(boolean importTags) {
+		set(SPEC_IMPORT, importTags);
+	}
+
+	@Override
+	public boolean isImport() {
+		return asBoolean(SPEC_IMPORT);
+	}
+
+	@Override
+	public void addImage(String fromKind, DockerImageURI imageUri) {
+		ModelNode image = new ModelNode();
+		set(image, FROM_KIND, fromKind);
+		set(image, "from.name", imageUri.getUriWithoutTag());
+		get(SPEC_IMAGES).add(image);
+	}
+
+	@Override
+	public Collection<IStatus> getImageStatus() {
+		Collection<IStatus> status = new ArrayList<>();
+		ModelNode images = get(STATUS_IMAGES);
+		if(images.isDefined()) {
+			images.asList()
+				.stream()
+				.filter(n->get(n,STATUS).isDefined())
+				.forEach(n->status.add(new Status(get(n,STATUS), getClient(), getPropertyKeys())));
+		}
+		return status;
+	}
+
+	@Override
+	public String getImageJsonFor(DockerImageURI uri) {
+		String prefix = uri.getUriWithoutTag();
+		ModelNode images = get(STATUS_IMAGES);
+		if(images.isDefined()) {
+			Optional<ModelNode> node = images.asList()
+				.stream()
+				.filter(n->asString(n, IMAGE_DOCKER_IMAGE_REFERENCE).startsWith(prefix))
+				.findFirst();
+			if(node.isPresent()) {
+				return node.get().toJSONString(true);
+			}
+		}		
+		return null;
+	}
+
+}

--- a/src/main/java/com/openshift/restclient/ResourceKind.java
+++ b/src/main/java/com/openshift/restclient/ResourceKind.java
@@ -28,6 +28,7 @@ public final class ResourceKind {
 	public static final String DEPLOYMENT_CONFIG = "DeploymentConfig";
 	public static final String IMAGE_STREAM = "ImageStream";
 	public static final String IMAGE_STREAM_TAG = "ImageStreamTag";
+	public static final String IMAGE_STREAM_IMPORT = "ImageStreamImport";
 	public static final String OAUTH_ACCESS_TOKEN = "OAuthAccessToken";
 	public static final String OAUTH_AUTHORIZE_TOKEN = "OAuthAuthorizeToken";
 	public static final String OAUTH_CLIENT = "OAuthClient";
@@ -89,6 +90,8 @@ public final class ResourceKind {
 		set.add(BUILD_CONFIG);
 		set.add(DEPLOYMENT_CONFIG);
 		set.add(IMAGE_STREAM );
+		set.add(IMAGE_STREAM_TAG);
+		set.add(IMAGE_STREAM_IMPORT);
 		set.add(OAUTH_ACCESS_TOKEN);
 		set.add(OAUTH_AUTHORIZE_TOKEN);
 		set.add(OAUTH_CLIENT);

--- a/src/main/java/com/openshift/restclient/capability/resources/IImageStreamImportCapability.java
+++ b/src/main/java/com/openshift/restclient/capability/resources/IImageStreamImportCapability.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.restclient.capability.resources;
+
+import com.openshift.restclient.capability.ICapability;
+import com.openshift.restclient.images.DockerImageURI;
+import com.openshift.restclient.model.image.IImageStreamImport;
+
+/**
+ * Import tags from a repository for an image
+ * 
+ * @author jeff.cantrill
+ *
+ */
+public interface IImageStreamImportCapability extends ICapability {
+
+	/**
+	 * Import docker image metadata
+	 * @param uri
+	 * @return
+	 * @throws OpenShiftException
+	 */
+	IImageStreamImport importImageMetadata(DockerImageURI uri);
+	
+}

--- a/src/main/java/com/openshift/restclient/model/IImageStream.java
+++ b/src/main/java/com/openshift/restclient/model/IImageStream.java
@@ -19,14 +19,26 @@ import com.openshift.restclient.model.image.ITagReference;
 public interface IImageStream extends IResource{
 
 	/**
-	 * Retrieve the docker image URI for which this image repository
-	 * is responsible
+	 * Get the image repository uri abstracted by this
+	 * image stream
 	 * @return
 	 */
 	DockerImageURI getDockerImageRepository();
 	
+	/**
+	 * Set the image repository uri abstracted by this
+	 * image stream
+	 * @return
+	 */
 	void setDockerImageRepository(DockerImageURI imageUri);
 	
+	/**
+	 * Set the image repository uri abstracted by this
+	 * image stream
+	 * @return
+	 */
+	void setDockerImageRepository(String imageUri);
+
 	/**
 	 * Sets a new tag in an image stream
 	 * 

--- a/src/main/java/com/openshift/restclient/model/image/IImageStreamImport.java
+++ b/src/main/java/com/openshift/restclient/model/image/IImageStreamImport.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.restclient.model.image;
+
+import java.util.Collection;
+
+import com.openshift.restclient.images.DockerImageURI;
+import com.openshift.restclient.model.IResource;
+import com.openshift.restclient.model.IStatus;
+
+/**
+ * 
+ * @author jeff.cantrill
+ *
+ */
+public interface IImageStreamImport extends IResource {
+
+	/**
+	 * Set to true to import tags for the imagestream; false to just retrieve
+	 * @param importTags
+	 */
+	void setImport(boolean importTags);
+	
+	/**
+	 * Are the tags to be imported for the imagestream
+	 * @return true if import; false otherwise
+	 */
+	boolean isImport();
+
+	/**
+	 * Add image info those being imorted
+	 * @param fromKind       The indirection of where to find the image.
+	 *                       Typically is DockerImage, ImageStreamTag 
+	 * @param uriWithoutTag
+	 */
+	void addImage(String fromKind, DockerImageURI imageUri);
+
+	/**
+	 * The status of the image retrieval
+	 * @return
+	 */
+	Collection<IStatus> getImageStatus();
+	
+	/**
+	 * Get the raw json docker metadata for
+	 * the given uir.  Tries to match uri without tag
+	 * to the beginning of image.dockerImageReference
+	 * 
+	 * @param uri
+	 * @return json string or null if not matched.
+	 */
+	String getImageJsonFor(DockerImageURI uri);
+}

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/ImageStreamImportCapabilityTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/ImageStreamImportCapabilityTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.capability.resources;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.IResourceFactory;
+import com.openshift.restclient.capability.resources.IImageStreamImportCapability;
+import com.openshift.restclient.images.DockerImageURI;
+import com.openshift.restclient.model.IProject;
+import com.openshift.restclient.model.image.IImageStreamImport;
+
+/**
+ * 
+ * @author jeff.cantrill
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ImageStreamImportCapabilityTest {
+
+	private IImageStreamImportCapability cap;
+	@Mock
+	private IProject project;
+	@Mock
+	private IClient client;
+	@Mock
+	private IResourceFactory factory;
+	@Mock
+	private IImageStreamImport streamImport;
+	
+	@Before
+	public void setUp() throws Exception {
+		when(project.getName()).thenReturn("aProjectName");
+		when(client.getResourceFactory()).thenReturn(factory);
+		when(factory.stub(anyString(), anyString(), anyString())).thenReturn(streamImport);
+		when(client.create(any(IImageStreamImport.class))).thenReturn(streamImport);
+		cap = new ImageStreamImportCapability(project, client);
+	}
+
+	@Test
+	public void testImportImageInfo() {
+		DockerImageURI image = new DockerImageURI("foo/hello-world");
+		IImageStreamImport imported = cap.importImageMetadata(image);
+		assertEquals(imported, streamImport);
+		
+		verify(client).create(streamImport);
+		verify(streamImport).addImage("DockerImage", image);
+		
+
+	}
+
+}

--- a/src/test/java/com/openshift/internal/restclient/model/v1/ImageStreamImportTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/ImageStreamImportTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: Red Hat, Inc.
+ ******************************************************************************/
+package com.openshift.internal.restclient.model.v1;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collection;
+
+import org.apache.commons.lang.StringUtils;
+import org.jboss.dmr.ModelNode;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.openshift.internal.restclient.model.image.ImageStreamImport;
+import com.openshift.internal.restclient.model.properties.ResourcePropertiesRegistry;
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.images.DockerImageURI;
+import com.openshift.restclient.model.IStatus;
+import com.openshift.restclient.model.image.IImageStreamImport;
+import com.openshift.restclient.utils.Samples;
+
+/**
+ * @author Jeff Cantrill
+ */
+public class ImageStreamImportTest {
+	private static final String VERSION = "v1";
+	private static IClient client;
+	private IImageStreamImport stream;
+
+	@Before
+	public void setup(){
+		client = mock(IClient.class);
+		ModelNode node = ModelNode.fromJSONString(Samples.V1_IMAGE_STREAM_IMPORT.getContentAsString());
+		stream = new ImageStreamImport(node, client, ResourcePropertiesRegistry.getInstance().get(VERSION, ResourceKind.IMAGE_STREAM_IMPORT));
+	}
+	
+	@Test
+	public void testImport() {
+		assertFalse(stream.isImport());
+		
+		stream.setImport(true);
+		assertTrue(stream.isImport());
+	}
+	
+	@Test
+	public void testGetImageStatus() {
+		Collection<IStatus> status = stream.getImageStatus();
+		assertEquals(1, status.size());
+		assertEquals("Success", status.iterator().next().getStatus());
+	}
+	
+	@Test
+	public void testGetImageJsonFor() {
+		DockerImageURI uri = new DockerImageURI("jcantrill/swarm-helloworld");
+		assertTrue(StringUtils.isNotBlank(stream.getImageJsonFor(uri)));
+
+		assertNull(stream.getImageJsonFor(new DockerImageURI("foo/bar")));
+	}
+}

--- a/src/test/java/com/openshift/restclient/utils/Samples.java
+++ b/src/test/java/com/openshift/restclient/utils/Samples.java
@@ -25,6 +25,7 @@ public enum Samples {
 	V1_BUILD_CONFIG_LIST("openshift3/v1_build_config_list.json"),
 	V1_DEPLOYMENT_CONIFIG("openshift3/v1_deployment_config.json"), 
 	V1_IMAGE_STREAM("openshift3/v1_image_stream.json"), 
+	V1_IMAGE_STREAM_IMPORT("openshift3/v1_image_stream_import.json"), 
 	V1_BUILD("openshift3/v1_build.json"), 
 	V1_OBJECT_REF("openshift3/v1_objectref.json"), 
 	V1_POD("openshift3/v1_pod.json"), 

--- a/src/test/resources/samples/openshift3/v1_image_stream.json
+++ b/src/test/resources/samples/openshift3/v1_image_stream.json
@@ -13,6 +13,7 @@
         }
     },
     "spec": {
+        "dockerImageRepository": "172.30.224.48:5000/openshift/wildfly",
         "tags": [
             {
                 "name": "8.1",

--- a/src/test/resources/samples/openshift3/v1_image_stream_import.json
+++ b/src/test/resources/samples/openshift3/v1_image_stream_import.json
@@ -1,0 +1,134 @@
+{
+  "kind": "ImageStreamImport",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "newapp",
+    "namespace": "hello-world",
+    "selfLink": "/oapi/v1/namespaces/hello-world/imagestreamimports/newapp",
+    "uid": "a7fe02b3-db38-11e5-b74a-080027c5bfa9",
+    "creationTimestamp": "2016-02-24T20:53:28Z"
+  },
+  "spec": {
+    "import": false,
+    "images": [
+      {
+        "from": {
+          "kind": "DockerImage",
+          "name": "jcantrill/swarm-helloworld"
+        },
+        "importPolicy": {}
+      }
+    ]
+  },
+  "status": {
+    "images": [
+      {
+        "status": {
+          "metadata": {},
+          "status": "Success"
+        },
+        "image": {
+          "metadata": {
+            "name": "sha256:445d9593cf8e7ac591ced715b38626751962beb3d164c28b99c69564aeeb6fd3",
+            "creationTimestamp": null
+          },
+          "dockerImageReference": "jcantrill/swarm-helloworld@sha256:445d9593cf8e7ac591ced715b38626751962beb3d164c28b99c69564aeeb6fd3",
+          "dockerImageMetadata": {
+            "kind": "DockerImage",
+            "apiVersion": "1.0",
+            "Id": "711e5ec1e370b6e7ab7d59bd3e7dd28b43d4f06c64ae50051622a2d59e82ecab",
+            "Parent": "dfe03d2d4a3eb77e50a3b8f7604b05f974b3a89e673af19efc6d5ac2d2c5c626",
+            "Created": "2016-02-23T14:52:02Z",
+            "Container": "26817295d7d6193ca4fafec76ac02367dd1cd85049f285741ddb8a1b7c8b443b",
+            "ContainerConfig": {
+              "Hostname": "82f7a8302f48",
+              "ExposedPorts": {
+                "8080/tcp": {}
+              },
+              "Env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+              ],
+              "Cmd": [
+                "/bin/sh",
+                "-c",
+                "#(nop) CMD [\"/bin/sh\" \"-c\" \"java -jar swarm-helloworld-1.0-SNAPSHOT-swarm.jar\"]"
+              ],
+              "Image": "dfe03d2d4a3eb77e50a3b8f7604b05f974b3a89e673af19efc6d5ac2d2c5c626",
+              "Labels": {
+                "build-date": "2016-02-17",
+                "license": "GPLv2",
+                "name": "CentOS Base Image",
+                "vendor": "CentOS"
+              }
+            },
+            "DockerVersion": "1.8.2-fc22",
+            "Author": "burrsutter@gmail.com",
+            "Config": {
+              "Hostname": "82f7a8302f48",
+              "ExposedPorts": {
+                "8080/tcp": {}
+              },
+              "Env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+              ],
+              "Cmd": [
+                "/bin/sh",
+                "-c",
+                "java -jar swarm-helloworld-1.0-SNAPSHOT-swarm.jar"
+              ],
+              "Image": "dfe03d2d4a3eb77e50a3b8f7604b05f974b3a89e673af19efc6d5ac2d2c5c626",
+              "Labels": {
+                "build-date": "2016-02-17",
+                "license": "GPLv2",
+                "name": "CentOS Base Image",
+                "vendor": "CentOS"
+              }
+            },
+            "Architecture": "amd64",
+            "Size": 448325253
+          },
+          "dockerImageMetadataVersion": "1.0",
+          "dockerImageLayers": [
+            {
+              "name": "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
+              "size": 0
+            },
+            {
+              "name": "sha256:ed99f9270efc5694a6f5a6fd276421a8b01ca1cd5c00c2d3e50a8068a8e16a1c",
+              "size": 196610919
+            },
+            {
+              "name": "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
+              "size": 0
+            },
+            {
+              "name": "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
+              "size": 0
+            },
+            {
+              "name": "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
+              "size": 0
+            },
+            {
+              "name": "sha256:85ff019b9a7c01d9d8b1b6f919cf2283e64b954d39acd91e1eb9acb92fa4edf7",
+              "size": 211205967
+            },
+            {
+              "name": "sha256:b4945d6bae1f222bd11097986dd111f2d48a964d5eb3423d4482d21cab838f21",
+              "size": 40508367
+            },
+            {
+              "name": "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
+              "size": 0
+            },
+            {
+              "name": "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
+              "size": 0
+            }
+          ]
+        },
+        "tag": "latest"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds support for ImageStreamImport to fix the referenced issue.  It allows image metadata to be retrieved via openshift without having a connection to a docker daemon

cc @adietish @fbricon 
[test]