### PR TITLE
Fixes in DockerImageURI

### DIFF
--- a/src/main/java/com/openshift/restclient/images/DockerImageURI.java
+++ b/src/main/java/com/openshift/restclient/images/DockerImageURI.java
@@ -16,7 +16,7 @@ package com.openshift.restclient.images;
  */
 public class DockerImageURI {
 	
-	private static final String LATEST = "latest";
+	public static final String LATEST = "latest";
 	private String registryHost;
 	private String userName;
 	private String name;
@@ -33,20 +33,22 @@ public class DockerImageURI {
 	}
 
 	public DockerImageURI(String tag){
-		String[] segments = tag.split("/");
-		switch (segments.length) {
-		case 3:
-			registryHost = segments[0];
-			userName = segments[1];
-			setNameAndTag(segments[2]);
-			break;
-		case 2:
-			userName = segments[0];
-			setNameAndTag(segments[1]);
-			break;
-		default:
-			setNameAndTag(segments[0]);
-			break;
+		if(tag != null) {
+			String[] segments = tag.split("/");
+			switch (segments.length) {
+			case 3:
+				registryHost = segments[0];
+				userName = segments[1];
+				setNameAndTag(segments[2]);
+				break;
+			case 2:
+				userName = segments[0];
+				setNameAndTag(segments[1]);
+				break;
+			default:
+				setNameAndTag(segments[0]);
+				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
Prevent NPE when tag is null in constructor.
make the 'LATEST' field public to reuse it elsewhere.