### PR TITLE
allow import of cert to the trust for ssl validation

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/DefaultClient.java
+++ b/src/main/java/com/openshift/internal/restclient/DefaultClient.java
@@ -13,6 +13,7 @@ import static com.openshift.internal.restclient.capability.CapabilityInitializer
 import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -85,8 +86,12 @@ public class DefaultClient implements IClient, IHttpConstants{
 	}
 	
 	public DefaultClient(URL baseUrl,  IHttpClient httpClient,  ISSLCertificateCallback sslCertCallback, IResourceFactory factory){
+		this(baseUrl, httpClient, sslCertCallback, factory, null, null);
+	}
+	
+	public DefaultClient(URL baseUrl,  IHttpClient httpClient,  ISSLCertificateCallback sslCertCallback, IResourceFactory factory, String alias, X509Certificate cert){
 		this.baseUrl = baseUrl;
-		client = httpClient != null ? httpClient : newIHttpClient(sslCertCallback);
+		client = httpClient != null ? httpClient : newIHttpClient(sslCertCallback, alias, cert);
 		this.factory = factory;
 		if(this.factory != null) {
 			this.factory.setClient(this);
@@ -100,9 +105,10 @@ public class DefaultClient implements IClient, IHttpConstants{
 	/*
 	 * Factory method for testing
 	 */
-	private IHttpClient newIHttpClient(ISSLCertificateCallback sslCertCallback){
+	private IHttpClient newIHttpClient(ISSLCertificateCallback sslCertCallback, String alias, X509Certificate cert){
 		return  new UrlConnectionHttpClientBuilder()
 		.setAcceptMediaType("application/json")
+		.setCertificate(alias, cert)
 		.setSSLCertificateCallback(sslCertCallback)
 		.client();
 	}
@@ -508,7 +514,7 @@ public class DefaultClient implements IClient, IHttpConstants{
 		this.authClient.setSSLCertificateCallback(callback);
 		this.client.setSSLCertificateCallback(callback);
 	}
-
+	
 	@Override
 	public int hashCode() {
 		final int prime = 31;

--- a/src/main/java/com/openshift/internal/restclient/http/UrlConnectionHttpClientBuilder.java
+++ b/src/main/java/com/openshift/internal/restclient/http/UrlConnectionHttpClientBuilder.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package com.openshift.internal.restclient.http;
 
+import java.security.cert.X509Certificate;
+
 import com.openshift.restclient.ISSLCertificateCallback;
 import com.openshift.restclient.authorization.BasicAuthorizationStrategy;
 import com.openshift.restclient.authorization.IAuthorizationStrategy;
@@ -27,6 +29,8 @@ public class UrlConnectionHttpClientBuilder {
 	private String version;
 	private Integer configTimeout;
 	private ISSLCertificateCallback callback;
+	private String certificateAlias;
+	private X509Certificate certificate;
 	private String excludeSSLCipherRegex;
 	private IAuthorizationStrategy authStrategy;
 
@@ -42,6 +46,12 @@ public class UrlConnectionHttpClientBuilder {
 	
 	public UrlConnectionHttpClientBuilder setCredentials(String username, String password, String token) {
 		return setAuthorizationStrategy(new BasicAuthorizationStrategy(username, password, token));
+	}
+	
+	public UrlConnectionHttpClientBuilder setCertificate(String alias, X509Certificate cert) {
+		this.certificateAlias = alias;
+		this.certificate = cert;
+		return this;
 	}
 	
 	public UrlConnectionHttpClientBuilder setConfigTimeout (Integer configTimeout) {
@@ -71,7 +81,7 @@ public class UrlConnectionHttpClientBuilder {
 	
 	public IHttpClient client() {
 		UrlConnectionHttpClient urlClient = new UrlConnectionHttpClient(
-				userAgent, acceptedMediaType, version, callback, configTimeout, excludeSSLCipherRegex);
+				userAgent, acceptedMediaType, version, callback, configTimeout, excludeSSLCipherRegex, certificateAlias, certificate);
 		urlClient.setAuthorizationStrategy(authStrategy);
 		return urlClient;
 	}

--- a/src/main/java/com/openshift/restclient/ClientBuilder.java
+++ b/src/main/java/com/openshift/restclient/ClientBuilder.java
@@ -12,6 +12,7 @@ package com.openshift.restclient;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.security.cert.X509Certificate;
 
 import com.openshift.internal.restclient.DefaultClient;
 import com.openshift.internal.restclient.ResourceFactory;
@@ -26,6 +27,8 @@ public class ClientBuilder {
 	
 	private String baseUrl;
 	private ISSLCertificateCallback sslCertificateCallback;
+	private X509Certificate certificate;
+	private String certificateAlias;
 	private IResourceFactory resourceFactory;
 	private IAuthorizationStrategy authStrategy;
 
@@ -35,6 +38,12 @@ public class ClientBuilder {
 	
 	public ClientBuilder sslCertificateCallback(ISSLCertificateCallback callback) {
 		this.sslCertificateCallback = callback;
+		return this;
+	}
+	
+	public ClientBuilder sslCertificate(String alias, X509Certificate cert) {
+		this.certificateAlias = alias;
+		this.certificate = cert;
 		return this;
 	}
 	
@@ -52,7 +61,7 @@ public class ClientBuilder {
 		try {
 			ISSLCertificateCallback sslCallback = defaultIfNull(this.sslCertificateCallback, new NoopSSLCertificateCallback());
 			IResourceFactory factory = defaultIfNull(resourceFactory, new ResourceFactory(null));
-			DefaultClient client = new DefaultClient(new URL(this.baseUrl), null, sslCallback, factory);
+			DefaultClient client = new DefaultClient(new URL(this.baseUrl), null, sslCallback, factory, certificateAlias, certificate);
 			
 			client.setAuthorizationStrategy(authStrategy);
 			

--- a/src/test/java/com/openshift/internal/restclient/DefaultClientTest.java
+++ b/src/test/java/com/openshift/internal/restclient/DefaultClientTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -204,6 +205,20 @@ public class DefaultClientTest {
 
 		assertThat(tokenClientTwo).isEqualTo(tokenClientTwo);
 	}
+
+	@Test
+	public void clientShouldEqualClientWithDifferentCert() throws Exception {
+		X509Certificate certOne = mock(X509Certificate.class);
+		when(certOne.getSigAlgName()).thenReturn("sig1");
+		DefaultClient certClientOne = new DefaultClient(baseUrl, null, null, null, "cert1", certOne);
+
+		X509Certificate certTwo = mock(X509Certificate.class);
+		when(certTwo.getSigAlgName()).thenReturn("sig2");
+		DefaultClient certClientTwo = new DefaultClient(baseUrl, null, null, null, "cert2", certTwo);
+
+		assertThat(certClientTwo).isEqualTo(certClientOne);
+	}
+
 
 
 


### PR DESCRIPTION
@jcantrill PTAL

This stems from the dialogue with @jim-minter I pulled you into a week or so ago.

This change allows the trust manager in UrlConnectionHttpClient.java to properly validate a server certificate (vs. skipping TLS verification and calling out to the ISSLCertificateCallback).

As an FYI, currently in jenkins-plugin I have to maintain my own TrustStore and validate the cert when UrlConnectionHttpClient calls the ISSLCertificateCallback (btw, this also revealed that the JDK does *NOT* use a singleton pattern when it comes to the TrustStore related stuff ... something I was not expecting :-) ).

Once some form of this change is in the 4.0.0-SNAPSHOT, I'll remove that extra TrustStore in jenkins-plugin and just set the cert being used via ClientBuilder.

Other note:  the trust store in AuthorizationClient was not getting involved in the SSL exchanges in my testing, so I did not update that one.  But let me know if there is some reason you want that one updated as well.