### PR TITLE
JBIDE-21326 - Server Adapter: Publishing is not telling me what it's doing

### DIFF
--- a/src/main/java/com/openshift/restclient/capability/resources/IPortForwardable.java
+++ b/src/main/java/com/openshift/restclient/capability/resources/IPortForwardable.java
@@ -117,6 +117,10 @@ public interface IPortForwardable extends IBinaryCapability {
 			return true;
 		}
 		
+		@Override
+		public String toString() {
+			return getName() + ": " + this.localPort + "->" + this.getRemotePort();
+		}
 		
 	}
 }

--- a/src/main/java/com/openshift/restclient/capability/resources/IRSyncable.java
+++ b/src/main/java/com/openshift/restclient/capability/resources/IRSyncable.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package com.openshift.restclient.capability.resources;
 
+import java.io.InputStream;
+
 import com.openshift.restclient.capability.IBinaryCapability;
 import com.openshift.restclient.model.IPod;
 
@@ -20,10 +22,16 @@ import com.openshift.restclient.model.IPod;
  */
 public interface IRSyncable extends IBinaryCapability {
 
-	void sync(Peer source, Peer destination);
+	/**
+	 * Synchronize the give {@code destination} with the given {@code source}
+	 * @param source the source of the rsync
+	 * @param destination the destination of the rsync
+	 * @return the underlying {@link Process} streams to be displayed in a console.
+	 */
+	InputStream sync(Peer source, Peer destination);
 		
 	/**
-	 * Stop forwarding ports, forcibly if necessary
+	 * Stop rsync'ing, forcibly if necessary.
 	 */
 	void stop();
 
@@ -96,4 +104,28 @@ public interface IRSyncable extends IBinaryCapability {
 		
 		public abstract boolean isPod();
 	}
+
+	/**
+	 * Indicates if the {@link Process} completed or not
+	 * 
+	 * @return <code>true</code> if the {@link Process} completed,
+	 *         <code>false</code> otherwise.
+	 */
+	boolean isDone();
+
+	/**
+	 * @return the {@link Process} exit value when it completed, {@code -1} if
+	 *         it's still running
+	 */
+	int exitValue();
+
+	/**
+	 * Blocks until the process is done.
+	 * 
+	 * @throws InterruptedException
+	 *             if the current thread is interrupted while waiting
+	 */
+	void await() throws InterruptedException;
+
+
 }

--- a/src/main/java/com/openshift/restclient/model/IResource.java
+++ b/src/main/java/com/openshift/restclient/model/IResource.java
@@ -24,20 +24,17 @@ public interface IResource extends ICapable, Annotatable {
 	Map<String, String> getMetadata();
 
 	/**
-	 * Retrieves the list of capabilities supported by this resource
-	 * @return
+	 * @return the list of capabilities supported by this resource
 	 */
 	Set<Class<? extends ICapability>>  getCapabilities();
 	
 	/**
-	 * Returns the resource kind
-	 * @return
+	 * @return the resource kind
 	 */
 	String getKind();
 	
 	/**
-	 * returns the version of this resource
-	 * @return
+	 * @return the version of this resource
 	 */
 	String getApiVersion();
 

--- a/src/test/java/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
+++ b/src/test/java/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+
+
+import java.io.BufferedInputStream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.openshift.internal.restclient.IntegrationTestHelper;
+import com.openshift.internal.restclient.authorization.AuthorizationClient;
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.authorization.BasicAuthorizationStrategy;
+import com.openshift.restclient.authorization.IAuthorizationClient;
+import com.openshift.restclient.authorization.IAuthorizationContext;
+import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
+import com.openshift.restclient.capability.CapabilityVisitor;
+import com.openshift.restclient.capability.IBinaryCapability;
+import com.openshift.restclient.capability.resources.IPodLogRetrieval;
+import com.openshift.restclient.model.IPod;
+
+/**
+ * 
+ * @author Jeff Cantrill
+ *
+ */
+public class OpenshiftBinaryRSyncRetrievalIntegrationTest {
+
+	private IntegrationTestHelper helper = new IntegrationTestHelper();
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@Test
+	public void testLogRetrieval() {
+		System.setProperty(IBinaryCapability.OPENSHIFT_BINARY_LOCATION, helper.getOpenShiftLocation());
+		IClient client = helper.createClient();
+		client.setAuthorizationStrategy(new BasicAuthorizationStrategy("admin", "admin", ""));
+		IAuthorizationClient authClient = new AuthorizationClient(client);
+		IAuthorizationContext context = authClient.getContext(client.getBaseURL().toString());
+		client.setAuthorizationStrategy(new TokenAuthorizationStrategy(context.getToken()));
+		client.get(ResourceKind.POD, "hello-openshift", "openshift-dev");
+		IPod pod = client.get(ResourceKind.POD, "hello-openshift", "openshift-dev");
+
+		pod.accept(new CapabilityVisitor<IPodLogRetrieval, Object>() {
+
+			@Override
+			public Object visit(IPodLogRetrieval cap) {
+				try {
+					BufferedInputStream os = new BufferedInputStream(cap.getLogs(true));
+					int c;
+					while((c = os.read()) != -1) {
+						System.out.print((char)c);
+					}
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+				return null;
+			}
+
+		}, new Object());
+	}
+}

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
@@ -1,0 +1,111 @@
+package com.openshift.internal.restclient.capability.resources;
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+
+import static org.fest.assertions.Assertions.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.openshift.internal.restclient.IntegrationTestHelper;
+import com.openshift.internal.restclient.ResourceFactory;
+import com.openshift.internal.restclient.authorization.AuthorizationClient;
+import com.openshift.restclient.ClientBuilder;
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.NoopSSLCertificateCallback;
+import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.authorization.BasicAuthorizationStrategy;
+import com.openshift.restclient.authorization.IAuthorizationClient;
+import com.openshift.restclient.authorization.IAuthorizationContext;
+import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
+import com.openshift.restclient.capability.CapabilityVisitor;
+import com.openshift.restclient.capability.IBinaryCapability;
+import com.openshift.restclient.capability.resources.IRSyncable;
+import com.openshift.restclient.capability.resources.IRSyncable.LocalPeer;
+import com.openshift.restclient.capability.resources.IRSyncable.PodPeer;
+import com.openshift.restclient.model.IPod;
+import com.openshift.restclient.model.IService;
+
+/**
+ * 
+ * @author Xavier Coulon
+ *
+ */
+public class OpenshiftBinaryRSyncRetrievalIntegrationTest {
+
+	/** The usual Logger.*/
+	private static final Logger LOGGER = LoggerFactory.getLogger(OpenshiftBinaryRSyncRetrievalIntegrationTest.class);
+	
+	private IntegrationTestHelper helper = new IntegrationTestHelper();
+
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@Test
+	public void testRSyncLogRetrieval() throws IOException {
+		// given
+		System.setProperty(IBinaryCapability.OPENSHIFT_BINARY_LOCATION, helper.getOpenShiftLocation());
+		final IClient client = new ClientBuilder(helper.getServerUrl()).resourceFactory(new ResourceFactory(null))
+				.sslCertificateCallback(new NoopSSLCertificateCallback()).build();
+		client.setAuthorizationStrategy(new BasicAuthorizationStrategy("test-admin", "test-admin", ""));
+		final IAuthorizationClient authClient = new AuthorizationClient(client);
+		final IAuthorizationContext context = authClient.getContext(client.getBaseURL().toString());
+		client.setAuthorizationStrategy(new TokenAuthorizationStrategy(context.getToken()));
+		// retrieve the first pod in the 'eap-app' service
+		final IService service = client.get(ResourceKind.SERVICE, "nodejs-example", "int-test");
+		final List<IPod> pods = service.getPods();
+		assertThat(pods).isNotEmpty();
+		final IPod pod = pods.get(0);
+		final String localDir = "/Users/xcoulon/git/nodejs-ex";
+		final String targetDir = "/tmp";
+		// when
+		// create a dummy file to be sure there will be something to rsync
+		final String fileName = File.createTempFile("test", ".txt", new File(localDir)).getName();
+		// run the rsync and collect the logs
+		final List<String> logs = new ArrayList<>(100);
+		pod.accept(new CapabilityVisitor<IRSyncable, Object>() {
+
+			@Override
+			public Object visit(IRSyncable cap) {
+				try {
+					System.out.println("**** RSync Logs ****");
+					final BufferedReader reader = new BufferedReader(new InputStreamReader(
+							cap.sync(new LocalPeer(localDir), new PodPeer(targetDir, pod))));
+					String line;
+					while((line = reader.readLine()) != null) {
+						System.out.println(line);
+						logs.add(line);
+					}
+					// wait until end of 'rsync'
+					cap.await();
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+				return null;
+			}
+
+		}, new Object());
+		// then
+		// verify that the logs contain a message about the dummy file
+		assertThat(logs).isNotEmpty();
+		assertThat(logs.stream().anyMatch(line -> line.contains(fileName))).isTrue();
+	}
+}

--- a/src/test/resources/openshiftv3IntegrationTest.properties
+++ b/src/test/resources/openshiftv3IntegrationTest.properties
@@ -1,5 +1,6 @@
 
 serverURL=https://127.0.0.1:8443
+#serverURL=https://10.2.2.2:8443
 
 #osadm policy add-cluster-role-to-user cluster-admin $ADMIN_USER --config=openshift.local.config/master/admin.kubeconfig
 default.clusteradmin.user=admin


### PR DESCRIPTION
The underlying 'rsync' process inputstream is returned to the caller
 when the OpenShiftBinaryRSync#sync(Peer, Peer) method is invoked.
This inputstream can be then displayed in the IDE console.

Also added some javadocs and an integration test (requires some setup)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>