### PR TITLE
JBIDE-21453 - Server Adapter: use rsync flag instead of local filtered-copy

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryPodLogRetrieval.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryPodLogRetrieval.java
@@ -15,7 +15,6 @@ import java.io.SequenceInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -95,7 +94,6 @@ public class OpenShiftBinaryPodLogRetrieval implements IPodLogRetrieval {
 		
 		private String container;
 		private boolean follow;
-		private Consumer<String> cacheFlush;
 		private SequenceInputStream is;
 
 		PodLogs(IClient client, boolean follow, String container){
@@ -141,20 +139,17 @@ public class OpenShiftBinaryPodLogRetrieval implements IPodLogRetrieval {
 
 		@Override
 		protected String buildArgs() {
-			StringBuilder args = new StringBuilder();
-			args.append("logs ");
-			addSkipTlsVerify(args);
-			addServer(args)
-			.append(" ").append(pod.getName()).append(" ")
-			.append("-n ").append(pod.getNamespace()).append(" ");
-			addToken(args);
+			final StringBuilder argsBuilder = new StringBuilder();
+			argsBuilder.append("logs ").append(getSkipTlsVerifyFlag()).append(getServerFlag()).append(" ")
+					.append(pod.getName()).append(" ").append("-n ").append(pod.getNamespace()).append(" ")
+					.append(getTokenFlag());
 			if(follow) {
-				args.append(" -f ");
+				argsBuilder.append(" -f ");
 			}
 			if(StringUtils.isNotBlank(container)) {
-				args.append( " -c ").append(container);
+				argsBuilder.append( " -c ").append(container);
 			}
-			return args.toString();
+			return argsBuilder.toString();
 		}
 	}
 	

--- a/src/main/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryPortForwarding.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryPortForwarding.java
@@ -68,17 +68,13 @@ public class OpenShiftBinaryPortForwarding extends AbstractOpenShiftBinaryCapabi
 
 	@Override
 	protected String buildArgs() {
-		StringBuilder args = new StringBuilder();
-		args.append("port-forward ");
-		addSkipTlsVerify(args);
-		addServer(args);
-		addToken(args)
-			.append("-n ").append(pod.getNamespace()).append(" ")
-			.append("-p ").append(pod.getName()).append(" ");
+		final StringBuilder argBuilder = new StringBuilder();
+		argBuilder.append("port-forward ").append(getSkipTlsVerifyFlag()).append(getServerFlag()).append(getTokenFlag())
+				.append("-n ").append(pod.getNamespace()).append(" ").append("-p ").append(pod.getName()).append(" ");
 		for (PortPair pair : pairs) {
-			args.append(pair.getLocalPort()).append(":").append(pair.getRemotePort()).append(" ");
+			argBuilder.append(pair.getLocalPort()).append(":").append(pair.getRemotePort()).append(" ");
 		}
-		return args.toString();
+		return argBuilder.toString();
 	}
 	
 }

--- a/src/main/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryRSync.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryRSync.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.openshift.internal.restclient.capability.resources;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
@@ -102,7 +103,7 @@ public class OpenShiftBinaryRSync extends AbstractOpenShiftBinaryCapability impl
 		}
 	}
 	
-	private String getErrorMessage(InputStream errorStream) {
+	private static String getErrorMessage(InputStream errorStream) {
 		try {
 			return IOUtils.toString(errorStream);
 		} catch (IOException e) {
@@ -124,7 +125,7 @@ public class OpenShiftBinaryRSync extends AbstractOpenShiftBinaryCapability impl
 				&& hasPodPeer(source, destination);
 	}
 
-	private boolean hasPodPeer(Peer source, Peer destination) {
+	private static boolean hasPodPeer(Peer source, Peer destination) {
 		return source.isPod()
 				|| destination.isPod();
 	}
@@ -141,15 +142,11 @@ public class OpenShiftBinaryRSync extends AbstractOpenShiftBinaryCapability impl
 	
 	@Override
 	protected String buildArgs() {
-		StringBuilder args = new StringBuilder("rsync ");
-		addUser(args);
-		addToken(args);
-		addServer(args);
-		addSkipTlsVerify(args)
-				.append(source.getParameter())
-				.append(" ")
+		final StringBuilder argsBuilder = new StringBuilder("rsync ");
+		argsBuilder.append(getUserFlag()).append(getTokenFlag()).append(getServerFlag()).append(getSkipTlsVerifyFlag())
+				.append(getExclusionFlags()).append(getNoPermsFlags()).append(source.getParameter()).append(" ")
 				.append(destination.getParameter());
-		return args.toString();
+		return argsBuilder.toString();
 	}
 	
 }


### PR DESCRIPTION
Add the "--exclude='.git'" flag in the rsync command to exclude the '.git'
 directory. Since there can be only one occurrence of this option,
 excluding the '.git' directory seems like the best choice.

Also refactored the methods that generate the command line flags to simply return
 a String that will be appended to the StringBuilder by the caller method.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>