### PR TITLE
add cross project tagging

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/model/ImageStream.java
+++ b/src/main/java/com/openshift/internal/restclient/model/ImageStream.java
@@ -86,6 +86,15 @@ public class ImageStream extends KubernetesResource implements IImageStream {
 	}
 
 	@Override
+	public ITagReference addTag(String name, String fromKind, String fromName, String fromNamespace) {
+		TagReference reference = new TagReference(name, fromKind, fromName, fromNamespace);
+		//add last since its copy of node.  future sets will do nothing
+		ModelNode tags = get(SPEC_TAGS);
+		tags.add(reference.getNode());
+		return reference;
+	}
+
+	@Override
 	public void setTag(String newTag, String fromTag) {
 		ModelNode tags = get(SPEC_TAGS);
 		ModelNode tag = new ModelNode();

--- a/src/main/java/com/openshift/internal/restclient/model/KubernetesResource.java
+++ b/src/main/java/com/openshift/internal/restclient/model/KubernetesResource.java
@@ -176,11 +176,11 @@ public class KubernetesResource implements IResource, ResourcePropertyKeys {
 	
 	@Override
 	public String getNamespace(){
-		return asString(NAMESPACE);
+		return asString(METADATA_NAMESPACE);
 	}
 	
 	public void setNamespace(String namespace){
-		set(NAMESPACE, namespace);
+		set(METADATA_NAMESPACE, namespace);
 	}
 
 	@Override

--- a/src/main/java/com/openshift/internal/restclient/model/ObjectReference.java
+++ b/src/main/java/com/openshift/internal/restclient/model/ObjectReference.java
@@ -42,6 +42,10 @@ public class ObjectReference implements IObjectReference {
 	public void setName(String name) {
 		set(node, KEYS, NAME, name);
 	}
+	
+	public void setNamespace(String namespace) {
+		set(node, KEYS, NAMESPACE, namespace);
+	}
 
 	@Override
 	public String getApiVersion() {

--- a/src/main/java/com/openshift/internal/restclient/model/image/TagReference.java
+++ b/src/main/java/com/openshift/internal/restclient/model/image/TagReference.java
@@ -35,6 +35,12 @@ public class TagReference extends ModelNodeAdapter implements ITagReference, Res
 		from.setName(fromName);
 	}
 	
+	public TagReference(String name, String fromKind, String fromName, String fromNamespace) {
+		this(name, fromKind, fromName);
+		ObjectReference from = (ObjectReference) getFrom();
+		from.setNamespace(fromNamespace);
+	}
+	
 	public TagReference(ModelNode node, Map<String, String[]> propertyKeys) {
 		super(node, propertyKeys);
 	}

--- a/src/main/java/com/openshift/internal/restclient/model/properties/ResourcePropertyKeys.java
+++ b/src/main/java/com/openshift/internal/restclient/model/properties/ResourcePropertyKeys.java
@@ -24,10 +24,11 @@ public interface ResourcePropertyKeys {
 	static final String METADATA = "metadata";
 	static final String METADATA_NAME = "metadata.name";
 	static final String METADATA_RESOURCE_VERSION = "metadata.resourceVersion";
-	static final String NAMESPACE = "metadata.namespace";
+	static final String METADATA_NAMESPACE = "metadata.namespace";
 
 	static final String FROM = "from";
 	static final String NAME = "name";
+	static final String NAMESPACE = "namespace";
 	static final String OBJECTS = "objects";
 	static final String PORTS = "ports";
 	static final String PROTOCOL = "protocol";

--- a/src/main/java/com/openshift/restclient/model/IImageStream.java
+++ b/src/main/java/com/openshift/restclient/model/IImageStream.java
@@ -58,6 +58,17 @@ public interface IImageStream extends IResource{
 	ITagReference addTag(String name, String fromKind, String fromName);
 	
 	/**
+	 * Add a tag to the list with the given name, namespace, and reference
+	 * to the given kind, namespace, and name.
+	 * @param name
+	 * @param fromKind
+	 * @param fromName
+	 * @param fromNamespace
+	 * @return
+	 */
+	ITagReference addTag(String name, String fromKind, String fromName, String fromNamespace);
+	
+	/**
 	 * Gets the long imagae id for the provided tag
 	 * @param tagName   name of the image stream tag to interrogate
 	 * @return

--- a/src/test/java/com/openshift/internal/restclient/model/KubernetesResourceTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/KubernetesResourceTest.java
@@ -54,7 +54,7 @@ public class KubernetesResourceTest {
 		annotations.get("template").set("foobar");
 		
 		node.get(KubernetesResource.METADATA_NAME).set("bartender");
-		node.get(KubernetesResource.NAMESPACE).set("foofighters");
+		node.get(KubernetesResource.METADATA_NAMESPACE).set("foofighters");
 		
 		return node;
 	}
@@ -207,7 +207,7 @@ public class KubernetesResourceTest {
 		assertEquals(resource, otherResource);
 
 		// operation
-		otherResource.set(KubernetesResource.NAMESPACE, "karate");
+		otherResource.set(KubernetesResource.METADATA_NAMESPACE, "karate");
 		
 		// verification
 		assertThat(resource).isNotEqualTo(otherResource);

--- a/src/test/java/com/openshift/internal/restclient/model/v1/ImageStreamTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/ImageStreamTest.java
@@ -58,6 +58,14 @@ public class ImageStreamTest {
 	}
 	
 	@Test
+	public void testAddTagWithNamespace() {
+		ITagReference tag = stream.addTag("1234", ResourceKind.IMAGE_STREAM_TAG, "foo/bar", "fromNmspc");
+		Optional<ITagReference> actTag = stream.getTags().stream().filter(t->"1234".equals(t.getName())).findFirst();
+		assertTrue("Exp. the tag to have been added",actTag.isPresent());
+		assertEquals(tag.toJson(), actTag.get().toJson());
+	}
+	
+	@Test
 	public void getDockerImageRepository() {
 		assertEquals(new DockerImageURI("172.30.224.48:5000/openshift/wildfly:latest"), stream.getDockerImageRepository());
 	}


### PR DESCRIPTION
@jcantrill PTAL

the jenkins plugin has a requirement to be able to `oc tag` across namespaces/projects; i'm currently handcrafting a ModelNode but got back around to updating the restclient API to do this; i'll leverage this form if you all are agreeable to merge

thanks