### PR TITLE
JBIDE-21981 - Error during rsync

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/capability/resources/AbstractOpenShiftBinaryCapability.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/resources/AbstractOpenShiftBinaryCapability.java
@@ -11,6 +11,8 @@
 package com.openshift.internal.restclient.capability.resources;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -56,10 +58,10 @@ public abstract class AbstractOpenShiftBinaryCapability implements IBinaryCapabi
 	protected abstract boolean validate();
 	
 	/**
-	 * Callback for building args to be sent to the oc command
-	 * @return
+	 * Callback for building args to be sent to the {@code oc} command.
+	 * @return the String representation of all the arguments to use when running the {@code oc} command. 
 	 */
-	protected abstract String buildArgs();
+	protected abstract String buildArgs(final List<OpenShiftBinaryOption> options);
 
 	protected IClient getClient() {
 		return client;
@@ -133,7 +135,7 @@ public abstract class AbstractOpenShiftBinaryCapability implements IBinaryCapabi
 	 *         not need to be synchronized between the remote pod and the local
 	 *         deployment directory.
 	 */
-	protected String getExclusionFlags() {
+	protected String getGitFolderExclusionFlag() {
 		// no support for multiple exclusion, so excluding '.git' only for now
 		// see https://github.com/openshift/origin/issues/8223
 		return "--exclude='.git' ";
@@ -148,17 +150,18 @@ public abstract class AbstractOpenShiftBinaryCapability implements IBinaryCapabi
 	
 	/**
 	 * Starts the {@link Process} to run the {@code oc} command.
+	 * @param options the command line options
 	 */
-	public final void start() {
+	public final void start(final OpenShiftBinaryOption... options) {
 		String location = getOpenShiftBinaryLocation();
 		if(!validate()) {
 			return;
 		}
-		startProcess(location);
+		startProcess(location, options);
 	}
 	
-	private void startProcess(String location) {
-		String cmdLine = new StringBuilder(location).append(' ').append(buildArgs()).toString();
+	private void startProcess(final String location, final OpenShiftBinaryOption... options) {
+		String cmdLine = new StringBuilder(location).append(' ').append(buildArgs(Arrays.asList(options))).toString();
 		String[] args = StringUtils.split(cmdLine, " ");
 		ProcessBuilder builder = new ProcessBuilder(args);
 		LOG.debug("OpenShift binary args: {}", builder.command());

--- a/src/main/java/com/openshift/restclient/capability/IBinaryCapability.java
+++ b/src/main/java/com/openshift/restclient/capability/IBinaryCapability.java
@@ -13,6 +13,18 @@ package com.openshift.restclient.capability;
  */
 public interface IBinaryCapability extends ICapability {
 	
+	/**
+	 * Optional arguments to pass when running the {@code oc} command.
+	 */
+	public enum OpenShiftBinaryOption {
+		/** option to skip verifying the certificates during TLS connection establishment. */
+		SKIP_TLS_VERIFY,
+		/** option to exclude the {@code .git} folder in the list of files/folders to synchronize. */
+		EXCLUDE_GIT_FOLDER,
+		/** option to not transfer file permissions. */
+		NO_PERMS;
+	}
+	
 	static final String OPENSHIFT_BINARY_LOCATION = "openshift.restclient.oc.location";
 
 }

--- a/src/main/java/com/openshift/restclient/capability/resources/IPodLogRetrieval.java
+++ b/src/main/java/com/openshift/restclient/capability/resources/IPodLogRetrieval.java
@@ -13,6 +13,7 @@ package com.openshift.restclient.capability.resources;
 import java.io.InputStream;
 
 import com.openshift.restclient.capability.ICapability;
+import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
 
 /**
  * 
@@ -23,20 +24,29 @@ public interface IPodLogRetrieval extends ICapability {
 	
 	
 	/**
-	 * Return the logs from the pod, optionally following them
-	 * @param   follow  true; if following, Default: false
-	 * @return  the log output stream
+	 * Return the logs from the pod, optionally following them.
+	 * 
+	 * @param follow
+	 *            <code>true</code> if following. Default: <code>false</code>
+	 * @param options
+	 *            the options to pass to the underlying {@code oc} command
+	 * @return the log output stream
 	 */
-	InputStream getLogs(boolean follow);
+	InputStream getLogs(boolean follow, OpenShiftBinaryOption... options);
 
 	/**
 	 * Return the logs from the pod, optionally following them
-	 * @param   follow  true; if following, Default: false
-	 * @param  container   the name of the container in the pod to get logs
-	 *                     uses the first container if empty
-	 * @return  the log output stream
+	 * 
+	 * @param follow
+	 *            true; if following, Default: false
+	 * @param container
+	 *            the name of the container in the pod to get logs uses the
+	 *            first container if empty
+	 * @param options
+	 *            the options to pass to the underlying {@code oc} command
+	 * @return the log output stream
 	 */
-	InputStream getLogs(boolean follow, String container);
+	InputStream getLogs(boolean follow, String container, OpenShiftBinaryOption... options);
 	
 	/**
 	 * Stop retrieving logs for all containers
@@ -45,6 +55,7 @@ public interface IPodLogRetrieval extends ICapability {
 
 	/**
 	 * Stop retrieving logs for a specific container
+	 * @param container the name of the container
 	 */
 	void stop(String container);
 

--- a/src/main/java/com/openshift/restclient/capability/resources/IPortForwardable.java
+++ b/src/main/java/com/openshift/restclient/capability/resources/IPortForwardable.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package com.openshift.restclient.capability.resources;
 
+import java.util.Collection;
+
 import com.openshift.restclient.OpenShiftException;
 import com.openshift.restclient.capability.IBinaryCapability;
 import com.openshift.restclient.model.IPort;
@@ -23,16 +25,18 @@ public interface IPortForwardable extends IBinaryCapability {
 
 	/**
 	 * Forward the ports to a pod.  This is a non-blocking call
-	 * @param pairs
+	 * @param pairs the pairs of local/remote ports to link together
+	 * @param options
+	 *            the options to pass to the underlying {@code oc} command
 	 * @throws OpenShiftException if unable to forward ports
 	 */
-	void forwardPorts(PortPair...pairs);
+	void forwardPorts(Collection<PortPair> pairs, OpenShiftBinaryOption...options);
 	
 	/**
 	 * The port pairs.
 	 * @return The pairs when forwarding or an empty array; 
 	 */
-	PortPair[] getPortPairs();
+	Collection<PortPair> getPortPairs();
 	
 	/**
 	 * Stop forwarding ports, forcibly if necessary

--- a/src/main/java/com/openshift/restclient/capability/resources/IRSyncable.java
+++ b/src/main/java/com/openshift/restclient/capability/resources/IRSyncable.java
@@ -26,9 +26,10 @@ public interface IRSyncable extends IBinaryCapability {
 	 * Synchronize the give {@code destination} with the given {@code source}
 	 * @param source the source of the rsync
 	 * @param destination the destination of the rsync
+	 * @param options the options to pass to the underlying {@code oc rsync} command
 	 * @return the underlying {@link Process} streams to be displayed in a console.
 	 */
-	InputStream sync(Peer source, Peer destination);
+	InputStream sync(Peer source, Peer destination, OpenShiftBinaryOption... options);
 		
 	/**
 	 * Stop rsync'ing, forcibly if necessary.

--- a/src/test/java/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
+++ b/src/test/java/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
@@ -26,6 +26,7 @@ import com.openshift.restclient.authorization.IAuthorizationContext;
 import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 import com.openshift.restclient.capability.CapabilityVisitor;
 import com.openshift.restclient.capability.IBinaryCapability;
+import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
 import com.openshift.restclient.capability.resources.IPodLogRetrieval;
 import com.openshift.restclient.model.IPod;
 
@@ -57,7 +58,7 @@ public class OpenshiftBinaryRSyncRetrievalIntegrationTest {
 			@Override
 			public Object visit(IPodLogRetrieval cap) {
 				try {
-					BufferedInputStream os = new BufferedInputStream(cap.getLogs(true));
+					BufferedInputStream os = new BufferedInputStream(cap.getLogs(true, OpenShiftBinaryOption.SKIP_TLS_VERIFY));
 					int c;
 					while((c = os.read()) != -1) {
 						System.out.print((char)c);

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryPortForwardingIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryPortForwardingIntegrationTest.java
@@ -13,6 +13,7 @@ package com.openshift.internal.restclient.capability.resources;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Arrays;
 
 import org.apache.commons.io.IOUtils;
 import org.jboss.dmr.ModelNode;
@@ -27,6 +28,7 @@ import com.openshift.restclient.IResourceFactory;
 import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.capability.CapabilityVisitor;
 import com.openshift.restclient.capability.IBinaryCapability;
+import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
 import com.openshift.restclient.capability.resources.IPortForwardable;
 import com.openshift.restclient.capability.resources.IPortForwardable.PortPair;
 
@@ -58,7 +60,7 @@ public class OpenshiftBinaryPortForwardingIntegrationTest {
 
 			@Override
 			public Object visit(IPortForwardable capability) {
-				capability.forwardPorts(new PortPair(8181, port));
+				capability.forwardPorts(Arrays.asList(new PortPair(8181, port)), OpenShiftBinaryOption.SKIP_TLS_VERIFY);
 				try {
 					Thread.sleep(5 * 1000);
 					curl();


### PR DESCRIPTION
The OpenShiftBinaryRSync#sync(Peer,Peer) returned an InputStream
that was the combination of the underlying Process#getInputStream()
with Process#getErrorStream(), which means that when an error occurred,
the process' error stream was already read and consumed, meaning that it
could not be read again when throwing an OpenShiftException.