### PR TITLE
fix sanitize to allow keys with empty content to handle port specs

### DIFF
--- a/src/main/java/com/openshift/internal/util/JBossDmrExtentions.java
+++ b/src/main/java/com/openshift/internal/util/JBossDmrExtentions.java
@@ -58,9 +58,7 @@ public class JBossDmrExtentions {
 				}else {
 					sanitize(child);
 				}
-				if(child.getType() == ModelType.OBJECT && child.keys().size() == 0) {
-					emptyKeys.add(key);
-				}else if(child.getType() == ModelType.LIST) {
+				if(child.getType() == ModelType.LIST) {
 					List<ModelNode> entries = child.asList();
 					if(entries.isEmpty()) {
 						emptyKeys.add(key);

--- a/src/test/java/com/openshift/internal/util/JBossDmrExtentionsTest.java
+++ b/src/test/java/com/openshift/internal/util/JBossDmrExtentionsTest.java
@@ -51,7 +51,7 @@ public class JBossDmrExtentionsTest {
 		node.get("xyz").add(complex);
 		node.get("def").add(new ModelNode());
 		node.get("abc").set("xyx");
-		assertEquals("{\"xyz\" : [1,3,{\"sub1a\" : \"avalue\"}], \"abc\" : \"xyx\"}", toJsonString(node, true));
+		assertEquals("{\"foo\" : {}, \"xyz\" : [1,3,{\"sub1\" : {}, \"sub1a\" : \"avalue\"}], \"abc\" : \"xyx\"}", toJsonString(node, true));
 	}
 	
 	@Test


### PR DESCRIPTION
[test] @fbricon @adietish 

during working on build from found an issue in our method to sanitize the json that was keeping us from getting port spec info from imagestream tags since all the relevant info is in the key.