### PR TITLE
Update maven-deploy-plugin to 2.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<version.shrinkwrap_shrinkwrap>1.0.0-beta-6</version.shrinkwrap_shrinkwrap>
 		<version.shrinkwrap_resolver>1.0.0-beta-5</version.shrinkwrap_resolver>
 		<version.shrinkwrap_descriptors>1.1.0-beta-1</version.shrinkwrap_descriptors>
-		
+
 		<!-- integration test properties file -->
 		<integrationtest.properties>${basedir}/src/test/resources/integrationTest.properties</integrationtest.properties>
 		<jar.outputDir>${project.build.directory}</jar.outputDir>
@@ -118,6 +118,10 @@
 					<configuration>
 						<outputDirectory>${jar.outputDir}</outputDirectory>
 					</configuration>
+				</plugin>
+				<plugin>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>2.8.2</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
This allows deploying to an alternate repository with 

mvn deploy -DaltSnapshotDeploymentRepository=jboss-snapshots-repository::default::https://origin-repository.jboss.org/nexus/content/repositories/snapshots

Signed-off-by: Fred Bricon <fbricon@gmail.com>