### PR TITLE
[OSJC-252] Make Container#setImage respect the pull spec

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/model/Container.java
+++ b/src/main/java/com/openshift/internal/restclient/model/Container.java
@@ -66,7 +66,7 @@ public class Container extends ModelNodeAdapter implements IContainer, ResourceP
 
 	@Override
 	public void setImage(DockerImageURI tag) {
-		set(node, propertyKeys, IMAGE, tag.getUriWithoutHost());
+		set(node, propertyKeys, IMAGE, tag.getAbsoluteUri());
 	}
 
 	@Override

--- a/src/test/java/com/openshift/internal/restclient/model/v1/ReplicationControllerTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/ReplicationControllerTest.java
@@ -256,7 +256,7 @@ public class ReplicationControllerTest {
 		node.get(path).clear();
 		
 		//setup
-		DockerImageURI uri = new DockerImageURI("aproject/an_image_name");
+		DockerImageURI uri = new DockerImageURI("arepo/aproject/an_image_name");
 		IPort port = mock(IPort.class);
 		when(port.getProtocol()).thenReturn("TCP");
 		when(port.getContainerPort()).thenReturn(8080);


### PR DESCRIPTION
fixes the case where the pull spec is being modified by the client code.

cc @fbricon 

[test]