### PR TITLE
[JBIDE-22423] fix unable to edit buildconfigs by only retrieving from…

### DIFF
--- a/src/main/java/com/openshift/internal/util/JBossDmrExtentions.java
+++ b/src/main/java/com/openshift/internal/util/JBossDmrExtentions.java
@@ -129,11 +129,13 @@ public class JBossDmrExtentions {
 		HashMap<String, String> map = new HashMap<String, String>();
 		if(propertyKeys != null){
 			String [] path = getPath(propertyKeys, key);
-			ModelNode node = root.get(path);
-			if( !node.isDefined())
-				return map;
-			for (String k : node.keys()) {
-				map.put(k, node.get(k).asString());
+			if(root.has(path)) {
+				ModelNode node = root.get(path);
+				if( !node.isDefined())
+					return map;
+				for (String k : node.keys()) {
+					map.put(k, node.get(k).asString());
+				}
 			}
 		}
 		return map;
@@ -152,23 +154,25 @@ public class JBossDmrExtentions {
 	public static Set asSet(ModelNode root, Map<String, String []> propertyKeys, String key, ModelType type){
 		Set set = new HashSet();
 		String [] path = getPath(propertyKeys, key);
-		ModelNode node = root.get(path);
-		if( !node.isDefined())
-			return set;
-		for (ModelNode entry : node.asList()) {
-			Object instance = null;
-			switch(type) {
-			case STRING:
-				instance = entry.asString();
-				break;
-			case BOOLEAN:
-				instance = entry.asBoolean();
-				break;
-			case INT:
-				instance = entry.asInt();
-			default:
+		if(root.has(path)){
+			ModelNode node = root.get(path);
+			if( !node.isDefined())
+				return set;
+			for (ModelNode entry : node.asList()) {
+				Object instance = null;
+				switch(type) {
+				case STRING:
+					instance = entry.asString();
+					break;
+				case BOOLEAN:
+					instance = entry.asBoolean();
+					break;
+				case INT:
+					instance = entry.asInt();
+				default:
+				}
+				set.add(instance);
 			}
-			set.add(instance);
 		}
 		return set;
 	}
@@ -199,11 +203,14 @@ public class JBossDmrExtentions {
 	 */
 	public static int asInt(ModelNode node, Map<String, String []> propertyKeys, String key){
 		String [] path = getPath(propertyKeys, key);
-		ModelNode modelNode = node.get(path);
-		if( !modelNode.isDefined()){
-			return 0;
+		if(node.has(path)) {
+			ModelNode modelNode = node.get(path);
+			if( !modelNode.isDefined()){
+				return 0;
+			}
+			return modelNode.asInt();
 		}
-		return modelNode.asInt();
+		return 0;
 	}
 	
 	/**
@@ -215,7 +222,9 @@ public class JBossDmrExtentions {
 	 * @throws UnregisteredPropertyException   if the property is not found in the property map
 	 */
 	public static String asString(ModelNode node, Map<String, String []> propertyKeys, String key){
-		ModelNode modelNode = node.get(getPath(propertyKeys, key));
+		String[] path = getPath(propertyKeys, key);
+		if(!node.has(path)) return "";
+		ModelNode modelNode = node.get(path);
 		if( !modelNode.isDefined()){
 			return "";
 		}
@@ -232,6 +241,7 @@ public class JBossDmrExtentions {
 	 */
 	public static boolean asBoolean(ModelNode node, Map<String, String []> propertyKeys, String key) {
 		String [] path = getPath(propertyKeys, key);
+		if(!node.has(path)) return false;
 		ModelNode modelNode = node.get(path);
 		if( !modelNode.isDefined()){
 			return false;

--- a/src/test/java/com/openshift/internal/util/JBossDmrExtentionsTest.java
+++ b/src/test/java/com/openshift/internal/util/JBossDmrExtentionsTest.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,6 +53,24 @@ public class JBossDmrExtentionsTest {
 		node.get("def").add(new ModelNode());
 		node.get("abc").set("xyx");
 		assertEquals("{\"foo\" : {}, \"xyz\" : [1,3,{\"sub1\" : {}, \"sub1a\" : \"avalue\"}], \"abc\" : \"xyx\"}", toJsonString(node, true));
+	}
+	
+	@Test
+	public void testGettersDoNotAddNodeToJsonTree() {
+		asMap(node, paths, "openshift.map");
+		assertFalse(node.has("openshift","map"));
+
+		asSet(node, paths, "openshift.set", ModelType.STRING);
+		assertFalse(node.has("openshift","set"));
+
+		asInt(node, paths, "openshift.int");
+		assertFalse(node.has("openshift","int"));
+
+		asString(node, paths, "openshift.string");
+		assertFalse(node.has("openshift","string"));
+
+		asBoolean(node, paths, "openshift.bool");
+		assertFalse(node.has("openshift","bool"));
 	}
 	
 	@Test


### PR DESCRIPTION
… nodes when the  key exists

cc @fbricon   This fixes the issue by only retrieving keys when they already exist.  DMR allows you to get().set() which results in the key being added to the tree.  There are cases where this is undesirable.