### PR TITLE
Allow empty lists in responses

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/model/List.java
+++ b/src/main/java/com/openshift/internal/restclient/model/List.java
@@ -41,17 +41,22 @@ public class List extends KubernetesResource implements IList{
 	public Collection<IResource> getItems(){
 		if(items == null) {
 			String key = getNode().has(OBJECTS) ? OBJECTS : "items";
-			Collection<ModelNode> nodes = get(key).asList();
-			items = new ArrayList<>(nodes.size());
-			IResourceFactory factory = getClient().getResourceFactory();
-			if(factory != null){
-				for (ModelNode node : nodes) {
-					if(kind != null && !node.get(KIND).isDefined()) {
-						set(node, KIND, kind);
+			ModelNode listNode = get(key);
+			if (listNode.isDefined()) {
+				Collection<ModelNode> nodes = get(key).asList();
+				items = new ArrayList<>(nodes.size());
+				IResourceFactory factory = getClient().getResourceFactory();
+				if (factory != null) {
+					for (ModelNode node : nodes) {
+						if (kind != null && !node.get(KIND).isDefined()) {
+							set(node, KIND, kind);
+						}
+						IResource resource = factory.create(node.toJSONString(true));
+						items.add(resource);
 					}
-					IResource resource = factory.create(node.toJSONString(true));
-					items.add(resource);
 				}
+			} else {
+				items = Collections.emptyList();
 			}
 		}
 		return Collections.unmodifiableCollection(items);

--- a/src/test/java/com/openshift/internal/restclient/model/v1/ListTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/ListTest.java
@@ -34,7 +34,6 @@ import com.openshift.restclient.utils.Samples;
 public class ListTest {
 	
 	private static final String VERSION = "v1";
-	private static IList resource;
 	private static IClient client;
 	
 	@BeforeClass
@@ -43,15 +42,26 @@ public class ListTest {
 		when(client.getBaseURL()).thenReturn(new URL("https://localhost:8443"));
 		when(client.getOpenShiftAPIVersion()).thenReturn(VERSION);
 		when(client.getResourceFactory()).thenReturn(new ResourceFactory(client));
-		ModelNode node = ModelNode.fromJSONString(Samples.V1_BUILD_CONFIG_LIST.getContentAsString());
-		resource = new List(node, client, null);
+	}
+
+	private IList createList(Samples sample) {
+		ModelNode node = ModelNode.fromJSONString(sample.getContentAsString());
+		return new List(node, client, null);
 	}
 	
 	@Test
 	public void testItemKindsAreDefined() {
+		IList resource = createList(Samples.V1_BUILD_CONFIG_LIST);
 		Collection<IResource> items = resource.getItems();
 		assertTrue("Expected to be entries in the list",items.size() >0 );
 		assertEquals(ResourceKind.BUILD_CONFIG, items.iterator().next().getKind());
+	}
+
+	@Test
+	public void testEmptyList() {
+		IList resource = createList(Samples.V1_CONFIG_MAP_LIST_EMPTY);
+		Collection<IResource> items = resource.getItems();
+		assertEquals(0, items.size());
 	}
 
 }

--- a/src/test/java/com/openshift/restclient/utils/Samples.java
+++ b/src/test/java/com/openshift/restclient/utils/Samples.java
@@ -25,8 +25,8 @@ public enum Samples {
 
 	V1_BUILD_CONFIG("openshift3/v1_build_config.json"),
 	V1_BUILD_CONFIG_LIST("openshift3/v1_build_config_list.json"),
-	V1_DEPLOYMENT_CONIFIG("openshift3/v1_deployment_config.json"), 
-	V1_IMAGE_STREAM("openshift3/v1_image_stream.json"), 
+	V1_DEPLOYMENT_CONIFIG("openshift3/v1_deployment_config.json"),
+	V1_IMAGE_STREAM("openshift3/v1_image_stream.json"),
 	V1_IMAGE_STREAM_IMPORT("openshift3/v1_image_stream_import.json"), 
 	V1_BUILD("openshift3/v1_build.json"), 
 	V1_OBJECT_REF("openshift3/v1_objectref.json"), 
@@ -46,7 +46,8 @@ public enum Samples {
 	V1_USER("openshift3/v1_user.json"),
 	V1_SECRET("openshift3/v1_secret.json"),
 	V1_UNRECOGNIZED("openshift3/v1_unrecognized.json"),
-	V1_CONFIG_MAP("openshift3/v1_config_map.json");
+	V1_CONFIG_MAP("openshift3/v1_config_map.json"),
+	V1_CONFIG_MAP_LIST_EMPTY("openshift3/v1_config_map_list_empty.json");
 
 	private static final String SAMPLES_FOLDER = "/samples/";
 

--- a/src/test/resources/samples/openshift3/v1_config_map_list_empty.json
+++ b/src/test/resources/samples/openshift3/v1_config_map_list_empty.json
@@ -1,0 +1,8 @@
+{
+    "kind": "ConfigMapList",
+    "apiVersion": "v1",
+    "metadata": {
+        "selfLink": "/api/v1/namespaces/fooproj/configmaps",
+        "resourceVersion": "1418",
+    }
+}


### PR DESCRIPTION
Even though empty lists are required for some parts of the API, other parts allow lists to not be
defined. This patch changes the behavior when the list is not defined by returning an empty list
rather than failing.

It would be nice to still get failure when the list is required, but that would require some more rework of the client API. Let me know what you think.