### PR TITLE
Allow secret volumes to be added to replication controllers. 

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/model/ReplicationController.java
+++ b/src/main/java/com/openshift/internal/restclient/model/ReplicationController.java
@@ -283,22 +283,40 @@ public class ReplicationController extends KubernetesResource implements IReplic
 		return container;
 	}
 	
-	private void addEmptyDirVolumeToPodSpec(VolumeMount volume) {
-		ModelNode volNode = get(VOLUMES);
+        private boolean hasVolumeNamed(ModelNode volNode, String name) {
 		if(volNode.isDefined()) {
 			List<ModelNode> podVolumes = volNode.asList();
 			for (ModelNode node : podVolumes) {
-				if(volume.getName().equals(asString(node,NAME))) {
-					//already exists
-					return;
+				if(name.equals(asString(node,NAME))) {
+					return true;
 				}
 			}
 		}
+                return false;
+	}
+
+        private void addEmptyDirVolumeToPodSpec(VolumeMount volume) {
+		ModelNode volNode = get(VOLUMES);
+                if (hasVolumeNamed(volNode, volume.getName())) {
+                        //already exists
+                        return;
+                }
 		ModelNode podVolume = volNode.add();
 		set(podVolume,NAME,volume.getName());
 		set(podVolume,"emptyDir.medium","");
 	}
-	
+
+        public void addSecretVolumeToPodSpec(IVolumeMount volume, String secretName) {
+		ModelNode volNode = get(VOLUMES);
+                if (hasVolumeNamed(volNode, volume.getName())) {
+                        //already exists
+                        return;
+                }
+		ModelNode podVolume = volNode.add();
+		set(podVolume,NAME,volume.getName());
+		set(podVolume,"secret.secretName",secretName);
+	}
+
 	@Override
 	public IContainer addContainer(String name) {
 		ModelNode containers = get(SPEC_TEMPLATE_CONTAINERS);

--- a/src/test/java/com/openshift/internal/restclient/model/v1/ReplicationControllerTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/ReplicationControllerTest.java
@@ -294,6 +294,22 @@ public class ReplicationControllerTest {
 		
 		JSONAssert.assertEquals(exp.toJSONString(false), container.toJSONString(), true);
 	}
-	
 
+	@Test
+	public void testAddSecretVolumeToPodSpec() throws JSONException {
+            IVolumeMount volumeMount = new IVolumeMount() {
+                    public String getName() { return "my-secret"; }
+                    public String getMountPath() { return "/path/to/my/secret/"; }
+                    public boolean isReadOnly() { return true; }
+                    public void setName(String name) {}
+                    public void setMountPath(String path) {}
+                    public void setReadOnly(boolean readonly) {}
+                };
+            ((ReplicationController) rc).addSecretVolumeToPodSpec(volumeMount, "the-secret");
+            Set<IVolumeSource> podSpecVolumes = rc.getVolumes();
+            Optional vol = podSpecVolumes.stream()
+                .filter(v->v.getName().equals(volumeMount.getName()))
+                .findFirst();
+            assertTrue("Expected to find secret volume in pod spec", vol.isPresent());
+        }
 }


### PR DESCRIPTION
This is only exposed through internal object. I realise there is some work in progress on volumes which will influence the public API when complete.