### PR TITLE
Add a volume source interface

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/model/volume/EmptyDirVolumeSource.java
+++ b/src/main/java/com/openshift/internal/restclient/model/volume/EmptyDirVolumeSource.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.model.volume;
+
+import com.openshift.restclient.model.volume.IEmptyDirVolumeSource;
+import com.openshift.restclient.model.volume.VolumeType;
+import org.jboss.dmr.ModelNode;
+
+import static com.openshift.internal.util.JBossDmrExtentions.asString;
+import static com.openshift.internal.util.JBossDmrExtentions.set;
+
+/**
+ * @author Ulf Lilleengen
+ */
+public class EmptyDirVolumeSource extends VolumeSource implements IEmptyDirVolumeSource {
+    private static final String PROP_MEDIUM = "medium";
+
+    private final ModelNode node;
+
+    public EmptyDirVolumeSource(ModelNode node) {
+        super(node);
+        this.node = node.get(VolumeType.EMPTY_DIR);
+    }
+
+    public EmptyDirVolumeSource(String name) {
+        this(new ModelNode());
+        setName(name);
+    }
+
+    @Override
+    public String getMedium() {
+        return asString(node, getPropertyKeys(), PROP_MEDIUM);
+    }
+
+    @Override
+    public void setMedium(String medium) {
+        set(node, getPropertyKeys(), PROP_MEDIUM, medium);
+    }
+}

--- a/src/main/java/com/openshift/internal/restclient/model/volume/PersistentVolumeClaimVolumeSource.java
+++ b/src/main/java/com/openshift/internal/restclient/model/volume/PersistentVolumeClaimVolumeSource.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.model.volume;
+
+import com.openshift.restclient.model.volume.IPersistentVolumeClaimVolumeSource;
+import com.openshift.restclient.model.volume.IVolumeSource;
+import com.openshift.restclient.model.volume.VolumeType;
+import org.jboss.dmr.ModelNode;
+
+import static com.openshift.internal.util.JBossDmrExtentions.asBoolean;
+import static com.openshift.internal.util.JBossDmrExtentions.asString;
+import static com.openshift.internal.util.JBossDmrExtentions.set;
+
+/**
+ * @author Ulf Lilleengen
+ */
+public class PersistentVolumeClaimVolumeSource
+    extends VolumeSource
+    implements IPersistentVolumeClaimVolumeSource {
+
+    private static final String PROP_CLAIM_NAME = "claimName";
+    private static final String PROP_READ_ONLY = "readOnly";
+    private final ModelNode node;
+
+    public PersistentVolumeClaimVolumeSource(ModelNode node) {
+        super(node);
+        this.node = node.get(VolumeType.PERSISTENT_VOLUME_CLAIM);
+    }
+
+    public PersistentVolumeClaimVolumeSource(String name) {
+        this(new ModelNode());
+        setName(name);
+    }
+
+    @Override
+    public String getClaimName() {
+        return asString(node, getPropertyKeys(), PROP_CLAIM_NAME);
+    }
+
+    @Override
+    public void setClaimName(String claimName) {
+        set(node, getPropertyKeys(), PROP_CLAIM_NAME, claimName);
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return asBoolean(node, getPropertyKeys(), PROP_READ_ONLY);
+    }
+
+    @Override
+    public void setReadOnly(boolean readOnly) {
+        set(node, getPropertyKeys(), PROP_READ_ONLY, readOnly);
+    }
+}

--- a/src/main/java/com/openshift/internal/restclient/model/volume/SecretVolumeSource.java
+++ b/src/main/java/com/openshift/internal/restclient/model/volume/SecretVolumeSource.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.model.volume;
+
+import com.openshift.restclient.model.volume.ISecretVolumeSource;
+import com.openshift.restclient.model.volume.VolumeType;
+import org.jboss.dmr.ModelNode;
+
+import static com.openshift.internal.util.JBossDmrExtentions.asString;
+import static com.openshift.internal.util.JBossDmrExtentions.set;
+
+/**
+ * @author Ulf Lilleengen
+ */
+public class SecretVolumeSource
+        extends VolumeSource
+        implements ISecretVolumeSource {
+
+    private static final String PROP_SECRET_NAME = "secretName";
+    private final ModelNode node;
+
+    public SecretVolumeSource(ModelNode node) {
+        super(node);
+        this.node = node.get(VolumeType.SECRET);
+    }
+
+    public SecretVolumeSource(String name) {
+        this(new ModelNode());
+        setName(name);
+    }
+
+    @Override
+    public String getSecretName() {
+        return asString(node, getPropertyKeys(), PROP_SECRET_NAME);
+    }
+
+    @Override
+    public void setSecretName(String secretName) {
+        set(node, getPropertyKeys(), PROP_SECRET_NAME, secretName);
+    }
+}

--- a/src/main/java/com/openshift/restclient/model/IReplicationController.java
+++ b/src/main/java/com/openshift/restclient/model/IReplicationController.java
@@ -174,5 +174,12 @@ public interface IReplicationController  extends IResource{
 	 */
 	Set<IVolumeSource> getVolumes();
 
+	/**
+	 * Adds a volume to the pod spec. If a volume with the same name already exists, the volume is not added.
+	 *
+	 * @param volumeSource The volume to add to the pod spec
+     */
+	void addVolume(IVolumeSource volumeSource);
+
 	void setContainers(Collection<IContainer> containers);
 }

--- a/src/main/java/com/openshift/restclient/model/volume/IEmptyDirVolumeSource.java
+++ b/src/main/java/com/openshift/restclient/model/volume/IEmptyDirVolumeSource.java
@@ -1,0 +1,9 @@
+package com.openshift.restclient.model.volume;
+
+/**
+ * @author Ulf Lilleengen
+ */
+public interface IEmptyDirVolumeSource extends IVolumeSource {
+    String getMedium();
+    void setMedium(String medium);
+}

--- a/src/main/java/com/openshift/restclient/model/volume/IPersistentVolumeClaimVolumeSource.java
+++ b/src/main/java/com/openshift/restclient/model/volume/IPersistentVolumeClaimVolumeSource.java
@@ -1,0 +1,11 @@
+package com.openshift.restclient.model.volume;
+
+/**
+ * @author Ulf Lilleengen
+ */
+public interface IPersistentVolumeClaimVolumeSource extends IVolumeSource {
+    String getClaimName();
+    void setClaimName(String claimName);
+    boolean isReadOnly();
+    void setReadOnly(boolean readOnly);
+}

--- a/src/main/java/com/openshift/restclient/model/volume/ISecretVolumeSource.java
+++ b/src/main/java/com/openshift/restclient/model/volume/ISecretVolumeSource.java
@@ -1,0 +1,9 @@
+package com.openshift.restclient.model.volume;
+
+/**
+ * @author Ulf Lilleengen
+ */
+public interface ISecretVolumeSource extends IVolumeSource {
+    String getSecretName();
+    void setSecretName(String secretName);
+}

--- a/src/main/java/com/openshift/restclient/model/volume/IVolumeSource.java
+++ b/src/main/java/com/openshift/restclient/model/volume/IVolumeSource.java
@@ -16,6 +16,9 @@ package com.openshift.restclient.model.volume;
  *
  */
 public interface IVolumeSource {
-
 	String getName();
+
+	void setName(String name);
+
+	String toJSONString();
 }

--- a/src/main/java/com/openshift/restclient/model/volume/VolumeType.java
+++ b/src/main/java/com/openshift/restclient/model/volume/VolumeType.java
@@ -30,6 +30,8 @@ public interface VolumeType {
 	static final String GLUSTERFS = "glusterfs";
 	static final String ISCSI = "iscsi";
 	static final String RBD = "rbd";
+	static final String SECRET = "secret";
+	static final String PERSISTENT_VOLUME_CLAIM = "persistentVolumeClaim";
 
 	static List<String> getTypes() {
 		return Arrays.asList(EMPTY_DIR,

--- a/src/test/java/com/openshift/internal/restclient/model/v1/EmptyDirVolumeSourceTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/EmptyDirVolumeSourceTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.model.v1;
+
+import com.openshift.internal.restclient.model.volume.EmptyDirVolumeSource;
+import com.openshift.internal.restclient.model.volume.PersistentVolumeClaimVolumeSource;
+import com.openshift.restclient.model.volume.IEmptyDirVolumeSource;
+import com.openshift.restclient.utils.Samples;
+import org.jboss.dmr.ModelNode;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Ulf Lilleengen
+ */
+public class EmptyDirVolumeSourceTest {
+
+    private IEmptyDirVolumeSource source;
+
+    @Before
+    public void setup() {
+        source = new EmptyDirVolumeSource(ModelNode.fromJSONString(Samples.V1_EMPTYDIR_VOLUME_SOURCE.getContentAsString()));
+    }
+
+    @Test
+    public void testDeserialization() {
+        assertThat(source.getName(), is("mysource"));
+        assertThat(source.getMedium(), is("mymedium"));
+    }
+
+    @Test
+    public void testPropertiesAreSet() {
+        source = new EmptyDirVolumeSource("mysource");
+        source.setName("newsource");
+        source.setMedium("newmedium");
+
+        assertThat(source.getName(), is("newsource"));
+        assertThat(source.getMedium(), is("newmedium"));
+    }
+
+    @Test
+    public void testSerialization() {
+        source.setName("newsource");
+        source.setMedium("newmedium");
+
+        String json = source.toJSONString();
+        IEmptyDirVolumeSource sourceDeserialized = new EmptyDirVolumeSource(ModelNode.fromJSONString(json));
+        assertThat(sourceDeserialized.getName(), is("newsource"));
+        assertThat(sourceDeserialized.getMedium(), is("newmedium"));
+    }
+}

--- a/src/test/java/com/openshift/internal/restclient/model/v1/PVCVolumeSourceTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/PVCVolumeSourceTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.model.v1;
+
+import com.openshift.internal.restclient.model.volume.PersistentVolumeClaimVolumeSource;
+import com.openshift.internal.restclient.model.volume.VolumeSource;
+import com.openshift.restclient.model.volume.IPersistentVolumeClaimVolumeSource;
+import com.openshift.restclient.utils.Samples;
+import org.jboss.dmr.ModelNode;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Ulf Lilleengen
+ */
+public class PVCVolumeSourceTest {
+    private IPersistentVolumeClaimVolumeSource source;
+
+    @Before
+    public void setup() {
+        source = (IPersistentVolumeClaimVolumeSource)VolumeSource.create(ModelNode.fromJSONString(Samples.V1_PVC_VOLUME_SOURCE.getContentAsString()));
+    }
+
+    @Test
+    public void testDeserialization() {
+        assertThat(source.getName(), is("mysource"));
+        assertThat(source.getClaimName(), is("myclaim"));
+        assertThat(source.isReadOnly(), is(true));
+    }
+
+    @Test
+    public void testPropertiesAreSet() {
+        source = new PersistentVolumeClaimVolumeSource("mysource");
+        source.setClaimName("myotherclaim");
+        source.setReadOnly(false);
+        source.setName("newsource");
+
+        assertThat(source.getName(), is("newsource"));
+        assertThat(source.getClaimName(), is("myotherclaim"));
+        assertThat(source.isReadOnly(), is(false));
+    }
+
+    @Test
+    public void testSerialization() {
+        source.setClaimName("myotherclaim");
+        source.setReadOnly(false);
+        source.setName("newsource");
+
+        String json = source.toJSONString();
+        IPersistentVolumeClaimVolumeSource sourceDeserialized = new PersistentVolumeClaimVolumeSource(ModelNode.fromJSONString(json));
+        assertThat(sourceDeserialized.getName(), is("newsource"));
+        assertThat(sourceDeserialized.getClaimName(), is("myotherclaim"));
+        assertThat(sourceDeserialized.isReadOnly(), is(false));
+    }
+}

--- a/src/test/java/com/openshift/internal/restclient/model/v1/ReplicationControllerTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/ReplicationControllerTest.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.openshift.internal.restclient.model.volume.SecretVolumeSource;
+import com.openshift.restclient.model.volume.ISecretVolumeSource;
 import org.jboss.dmr.ModelNode;
 import org.json.JSONException;
 import org.junit.Before;
@@ -305,7 +307,9 @@ public class ReplicationControllerTest {
                     public void setMountPath(String path) {}
                     public void setReadOnly(boolean readonly) {}
                 };
-            ((ReplicationController) rc).addSecretVolumeToPodSpec(volumeMount, "the-secret");
+            SecretVolumeSource source = new SecretVolumeSource(volumeMount.getName());
+		    source.setSecretName("the-secret");
+	        rc.addVolume(source);
             Set<IVolumeSource> podSpecVolumes = rc.getVolumes();
             Optional vol = podSpecVolumes.stream()
                 .filter(v->v.getName().equals(volumeMount.getName()))

--- a/src/test/java/com/openshift/internal/restclient/model/v1/SecretVolumeSourceTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/SecretVolumeSourceTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.model.v1;
+
+import com.openshift.internal.restclient.model.volume.SecretVolumeSource;
+import com.openshift.restclient.model.volume.ISecretVolumeSource;
+import com.openshift.restclient.utils.Samples;
+import org.jboss.dmr.ModelNode;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Ulf Lilleengen
+ */
+public class SecretVolumeSourceTest {
+    private ISecretVolumeSource source;
+
+    @Before
+    public void setup() {
+        source = new SecretVolumeSource(ModelNode.fromJSONString(Samples.V1_SECRET_VOLUME_SOURCE.getContentAsString()));
+    }
+
+    @Test
+    public void testDeserialization() {
+        assertThat(source.getName(), is("mysource"));
+        assertThat(source.getSecretName(), is("mysecret"));
+    }
+
+    @Test
+    public void testPropertiesAreSet() {
+        source = new SecretVolumeSource("mysource");
+        source.setName("newsource");
+        source.setSecretName("newsecret");
+
+        assertThat(source.getName(), is("newsource"));
+        assertThat(source.getSecretName(), is("newsecret"));
+    }
+
+    @Test
+    public void testSerialization() {
+        source.setName("newsource");
+        source.setSecretName("newsecret");
+
+        String json = source.toJSONString();
+        ISecretVolumeSource sourceDeserialized = new SecretVolumeSource(ModelNode.fromJSONString(json));
+        assertThat(sourceDeserialized.getName(), is("newsource"));
+        assertThat(sourceDeserialized.getSecretName(), is("newsecret"));
+    }
+}

--- a/src/test/java/com/openshift/restclient/utils/Samples.java
+++ b/src/test/java/com/openshift/restclient/utils/Samples.java
@@ -52,7 +52,10 @@ public enum Samples {
 	V1_SECRET("openshift3/v1_secret.json"),
 	V1_UNRECOGNIZED("openshift3/v1_unrecognized.json"),
 	V1_CONFIG_MAP("openshift3/v1_config_map.json"),
-	V1_CONFIG_MAP_LIST_EMPTY("openshift3/v1_config_map_list_empty.json");
+	V1_CONFIG_MAP_LIST_EMPTY("openshift3/v1_config_map_list_empty.json"),
+	V1_EMPTYDIR_VOLUME_SOURCE("openshift3/v1_empty_dir_volume_source.json"),
+	V1_SECRET_VOLUME_SOURCE("openshift3/v1_secret_volume_source.json"),
+	V1_PVC_VOLUME_SOURCE("openshift3/v1_pvc_volume_source.json");
 
 	private static final String SAMPLES_FOLDER = "/samples/";
 

--- a/src/test/resources/samples/openshift3/v1_empty_dir_volume_source.json
+++ b/src/test/resources/samples/openshift3/v1_empty_dir_volume_source.json
@@ -1,0 +1,6 @@
+{
+    "name": "mysource",
+    "emptyDir": {
+        "medium": "mymedium"
+    }
+}

--- a/src/test/resources/samples/openshift3/v1_pvc_volume_source.json
+++ b/src/test/resources/samples/openshift3/v1_pvc_volume_source.json
@@ -1,0 +1,7 @@
+{
+    "name": "mysource",
+    "persistentVolumeClaim": {
+        "claimName": "myclaim",
+        "readOnly": true
+    }
+}

--- a/src/test/resources/samples/openshift3/v1_secret_volume_source.json
+++ b/src/test/resources/samples/openshift3/v1_secret_volume_source.json
@@ -1,0 +1,6 @@
+{
+    "name": "mysource",
+    "secret": {
+        "secretName": "mysecret"
+    }
+}


### PR DESCRIPTION
This pull request adds an interface to the replicationcontroller for adding volumes to a pod spec. I have only implemented support for EmptyDir, Secret and PersistentVolumeClaim, as that is what we need right now. Adding other implementations should be straightforward.