### PR TITLE
fix watch client queue

### DIFF
--- a/src/main/java/com/openshift/restclient/ClientBuilder.java
+++ b/src/main/java/com/openshift/restclient/ClientBuilder.java
@@ -33,6 +33,7 @@ import com.openshift.internal.restclient.okhttp.ResponseCodeInterceptor;
 import com.openshift.restclient.http.IHttpConstants;
 import com.openshift.restclient.utils.SSLUtils;
 
+import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 
 /**
@@ -50,6 +51,9 @@ public class ClientBuilder {
 	private String userName;
 	private String token;
 	private String password;
+	
+	private int maxRequests = 64;
+	private int maxRequestsPerHost = 10;
 	
 	private int readTimeout = IHttpConstants.DEFAULT_READ_TIMEOUT;
 	private TimeUnit readTimeoutUnit = TimeUnit.MILLISECONDS;
@@ -150,10 +154,17 @@ public class ClientBuilder {
 
 			ResponseCodeInterceptor responseCodeInterceptor = new ResponseCodeInterceptor();
 			OpenShiftAuthenticator authenticator = new OpenShiftAuthenticator();
+			Dispatcher dispatcher = new Dispatcher();
+			
+			//hiding these for now to since not certain
+			//if we need to really expose them.
+			dispatcher.setMaxRequests(maxRequests);
+			dispatcher.setMaxRequestsPerHost(maxRequestsPerHost);
 
 			OkHttpClient.Builder builder = new OkHttpClient.Builder()
 				.addInterceptor(responseCodeInterceptor)
 				.authenticator(authenticator)
+				.dispatcher(dispatcher)
 				.readTimeout(readTimeout, readTimeoutUnit)
 				.writeTimeout(writeTimeout, writeTimeoutUnit)
 				.connectTimeout(connectTimeout, connectTimeoutUnit)

--- a/src/test/java/com/openshift/internal/restclient/okhttp/WatchClientTest.java
+++ b/src/test/java/com/openshift/internal/restclient/okhttp/WatchClientTest.java
@@ -8,20 +8,38 @@
  * Contributors:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package com.openshift.internal.restclient;
+package com.openshift.internal.restclient.okhttp;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
 
 import org.junit.Test;
 
+import com.openshift.internal.restclient.DefaultClient;
+import com.openshift.internal.restclient.okhttp.WatchClient.WatchEndpoint;
+import com.openshift.restclient.IOpenShiftWatchListener;
+import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.IOpenShiftWatchListener.ChangeType;
 
 /**
  * @author Andre Dietisheim
  */
 public class WatchClientTest {
+	
+	@Test
+	public void testOnFailureCallBackNotifiesListener() {
+		DefaultClient client = null;
+		
+		IOpenShiftWatchListener listener = mock(IOpenShiftWatchListener.class);
+		
+		WatchEndpoint endpoint = new WatchEndpoint(client, listener, ResourceKind.BUILD);
+		endpoint.onFailure(new IOException(), null);
+		verify(listener).error(any(Throwable.class));
+	}
 
 	@Test
 	public void changeTypeShouldEqualSameChangeType() {

--- a/src/test/java/com/openshift/restclient/WatchClientIntegrationTest.java
+++ b/src/test/java/com/openshift/restclient/WatchClientIntegrationTest.java
@@ -39,6 +39,16 @@ public class WatchClientIntegrationTest {
 	private IntegrationTestHelper helper = new IntegrationTestHelper();
 	private IClient client;
 	private IResource project;
+	public static final String [] KINDS = new String[] {
+			ResourceKind.BUILD_CONFIG, 
+			ResourceKind.DEPLOYMENT_CONFIG, 
+			ResourceKind.SERVICE, 
+			ResourceKind.POD,
+			ResourceKind.REPLICATION_CONTROLLER, 
+			ResourceKind.BUILD, 
+			ResourceKind.IMAGE_STREAM, 
+			ResourceKind.ROUTE
+	};
 
 	private ExecutorService service;
 	private boolean isError;
@@ -58,10 +68,10 @@ public class WatchClientIntegrationTest {
 	}
 	
 	@SuppressWarnings("rawtypes")
-	@Test(timeout=30000)
+	@Test(timeout=60000)
 	public void test() throws Exception{
 		List results = new ArrayList();
-		CountDownLatch latch = new CountDownLatch(2);
+		CountDownLatch latch = new CountDownLatch(KINDS.length);
 		IOpenShiftWatchListener listener = new IOpenShiftWatchListener() {
 
 			@SuppressWarnings("unchecked")
@@ -90,7 +100,7 @@ public class WatchClientIntegrationTest {
 		
 		IWatcher watcher = null;
 		try {
-			watcher = client.watch(project.getName(), listener, ResourceKind.SERVICE, ResourceKind.POD);
+			watcher = client.watch(project.getName(), listener, KINDS);
 			latch.await();
 			assertFalse("Expected connection without error",isError);
 			IService service = client.getResourceFactory().stub(ResourceKind.SERVICE,"hello-world", project.getName());


### PR DESCRIPTION
This PR fixes an issue from the okHttp client refactor that

* limited the number of running requests during watch
* clones the underlying client for each watch

cc @fbricon @adietish @scabanovich 