### PR TITLE
[OSJC-264] - Commit a821fd51cbec9fa9ea9f25a6f4b2603b3ba5271e breaks sync feature

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/capability/resources/AbstractOpenShiftBinaryCapability.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/resources/AbstractOpenShiftBinaryCapability.java
@@ -155,7 +155,7 @@ public abstract class AbstractOpenShiftBinaryCapability implements IBinaryCapabi
 		String cmdLine = new StringBuilder(location).append(' ').append(buildArgs(Arrays.asList(options))).toString();
 		String[] args = StringUtils.split(cmdLine, " ");
 		ProcessBuilder builder = new ProcessBuilder(args);
-		builder.environment().clear();
+		builder.environment().remove("KUBECONFIG");
 		LOG.debug("OpenShift binary args: {}", builder.command());
 		try {
 			process = builder.start();


### PR DESCRIPTION
Replace env clear by remove('KUBECONFIG')

Signed-off-by: Jeff MAURY <jmaury@redhat.com>