### PR TITLE
Adding pod exec function

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/DefaultClient.java
+++ b/src/main/java/com/openshift/internal/restclient/DefaultClient.java
@@ -253,10 +253,14 @@ public class DefaultClient implements IClient, IHttpConstants{
 	}
 
 	public Request.Builder newRequestBuilderTo(String endpoint){
+		return newRequestBuilderTo(endpoint, MEDIATYPE_APPLICATION_JSON);
+	}
+
+	public Request.Builder newRequestBuilderTo(String endpoint,String acceptMediaType){
 		Request.Builder builder = new Request.Builder()
-			.url(endpoint.toString())
-			.header(PROPERTY_ACCEPT, MEDIATYPE_APPLICATION_JSON);
-		
+				.url(endpoint.toString())
+				.header(PROPERTY_ACCEPT, acceptMediaType);
+
 		String token =  null;
 		if(this.authContext != null &&  StringUtils.isNotBlank(this.authContext.getToken())){
 			token = this.authContext.getToken();
@@ -264,7 +268,8 @@ public class DefaultClient implements IClient, IHttpConstants{
 		builder.header(IHttpConstants.PROPERTY_AUTHORIZATION, String.format("%s %s", IHttpConstants.AUTHORIZATION_BEARER, token));
 		return builder;
 	}
-	
+
+
 	@Override
 	public <T extends IResource> T update(T resource) {
 		return execute(HttpMethod.PUT, resource.getKind(), resource.getNamespace(), resource.getName(), null, resource);

--- a/src/main/java/com/openshift/internal/restclient/URLBuilder.java
+++ b/src/main/java/com/openshift/internal/restclient/URLBuilder.java
@@ -8,19 +8,6 @@
  ******************************************************************************/
 package com.openshift.internal.restclient;
 
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.openshift.restclient.IApiTypeMapper;
 import com.openshift.restclient.IApiTypeMapper.IVersionedApiResource;
 import com.openshift.restclient.OpenShiftException;
@@ -28,6 +15,18 @@ import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.UnsupportedEndpointException;
 import com.openshift.restclient.http.IHttpConstants;
 import com.openshift.restclient.model.IResource;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Helper class to build the URL connection string in the proper
@@ -42,7 +41,7 @@ public class URLBuilder {
 	private String baseUrl;
 	private String kind;
 	private String name;
-	private Map<String, String> params = new HashMap<String, String>();
+	private ArrayList<AbstractMap.SimpleEntry<String,String>> params = new ArrayList<>();
 	private final IApiTypeMapper typeMappings;
 
 	private String apiVersion;
@@ -105,7 +104,7 @@ public class URLBuilder {
 	}
 
 	public URLBuilder addParmeter(String key, String value) {
-		params.put(key, value);
+		params.add(new AbstractMap.SimpleEntry<>( key, value ));
 		return this;
 	}
 	
@@ -175,10 +174,8 @@ public class URLBuilder {
 	private StringBuilder appendParameters(StringBuilder url) {
 		if (!params.isEmpty()) {
 			url.append(IHttpConstants.QUESTION_MARK);
-			for (Iterator<Entry<String, String>> iterator = params.entrySet()
-					.iterator(); iterator.hasNext();) {
-				Entry<String, String> entry = (Entry<String, String>) iterator
-						.next();
+			for ( Iterator<AbstractMap.SimpleEntry<String,String>> iterator = params.iterator(); iterator.hasNext(); ) {
+				AbstractMap.SimpleEntry<String,String> entry = iterator.next();
 				try {
 					if(StringUtils.isNotBlank(entry.getValue())) {
 						url.append(entry.getKey())

--- a/src/main/java/com/openshift/internal/restclient/api/capabilities/PodExec.java
+++ b/src/main/java/com/openshift/internal/restclient/api/capabilities/PodExec.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.api.capabilities;
+
+import com.openshift.internal.restclient.DefaultClient;
+import com.openshift.internal.restclient.URLBuilder;
+import com.openshift.internal.restclient.capability.AbstractCapability;
+import com.openshift.internal.restclient.okhttp.ResponseCodeInterceptor;
+import com.openshift.internal.restclient.okhttp.WebSocketAdapter;
+import com.openshift.restclient.IApiTypeMapper;
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.capability.IStoppable;
+import com.openshift.restclient.api.capabilities.IPodExec;
+import com.openshift.restclient.http.IHttpConstants;
+import com.openshift.restclient.model.IPod;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.ws.WebSocket;
+import okhttp3.ws.WebSocketCall;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class PodExec extends AbstractCapability implements IPodExec {
+
+	private static final Logger LOG = LoggerFactory.getLogger(IPodExec.class);
+	private static final String CAPABILITY = "exec";
+
+	private static final String COMMAND = "command";
+
+	private static final String K8S_PROTOCOL_HEADER = "X-Stream-Protocol-Version";
+
+	private static final String K8S_PROTOCOL = "channel.k8s.io";
+
+	public static final int CHANNEL_STDOUT = 1;
+	public static final int CHANNEL_STDERR = 2;
+	public static final int CHANNEL_EXECERR = 3;
+
+	private final IPod pod;
+	private final DefaultClient client;
+	private final IApiTypeMapper mapper;
+
+	public PodExec(IPod pod, IClient client) {
+		super( pod, client, CAPABILITY );
+		this.pod = pod;
+		this.client = client.adapt(DefaultClient.class);
+		this.mapper = client.adapt(IApiTypeMapper.class);
+	}
+	
+	@Override
+	public String getName() {
+		return PodExec.class.getSimpleName();
+	}
+
+	@Override
+	public IStoppable start( IPodExecOutputListener listener, Options options, String... commands ) {
+
+		if ( options == null ) {
+			options = new Options();
+		}
+
+		Map<String,String> parameters = options.getMap();
+
+		OkHttpClient okClient = client.adapt(OkHttpClient.class);
+
+		URLBuilder urlBuilder = new URLBuilder(client.getBaseURL(), mapper)
+				.resource(pod)
+				.subresource(CAPABILITY)
+				.addParameters(parameters);
+
+		// The main command and all arguments are specified as 'command' parameters
+		for ( String command : commands ) {
+			urlBuilder.addParmeter( COMMAND, command );
+		}
+
+		final String endpoint = urlBuilder.websocket();
+
+		Request request = client.newRequestBuilderTo(endpoint, IHttpConstants.MEDIATYPE_ANY)
+				.method( "GET", null )
+				.addHeader(K8S_PROTOCOL_HEADER, K8S_PROTOCOL )
+				// Unless we mark this as ignored, exceptions triggered by interceptor would be lost in dispatcher thread
+				.tag( new ResponseCodeInterceptor.Ignore() {} )
+				.build();
+
+		WebSocketCall call = WebSocketCall.create(okClient, request);
+		ExecOutputListenerAdapter adapter = new ExecOutputListenerAdapter(call, listener);
+		call.enqueue(adapter);
+		return adapter;
+	}
+
+	static class ExecOutputListenerAdapter extends WebSocketAdapter implements IStoppable{
+
+		private final IPodExecOutputListener listener;
+		private final WebSocketCall call;
+		private AtomicBoolean open = new AtomicBoolean(false);
+
+		public ExecOutputListenerAdapter(WebSocketCall call, IPodExecOutputListener listener) {
+			this.call = call;
+			this.listener = listener;
+		}
+
+		@Override
+		public void stop() {
+			call.cancel();
+		}
+
+		@Override
+		public void onOpen(WebSocket webSocket, Response response) {
+			if(open.compareAndSet(false, true)) {
+				listener.onOpen();
+			}
+		}
+
+		@Override
+		public void onClose(int code, String reason) {
+			if( open.compareAndSet(true, false) ) {
+				listener.onClose(code, reason);
+			}
+		}
+
+		@Override
+		public void onFailure(IOException e, Response response) {
+			listener.onFailure(e);
+		}
+
+		public void deliver( int channel, String msg ) {
+			switch ( channel ) {
+				case CHANNEL_STDOUT:
+					listener.onStdOut(msg);
+					break;
+				case CHANNEL_STDERR:
+					listener.onStdErr(msg);
+					break;
+				case CHANNEL_EXECERR:
+					listener.onExecErr(msg);
+					break;
+				default:
+					LOG.warn("Unable to deliver exec message of type [%d]: %s", channel, msg );
+			}
+		}
+
+		@Override
+		public void onMessage(ResponseBody message) throws IOException {
+
+			/**
+			 * https://godoc.org/k8s.io/kubernetes/pkg/util/wsstream
+			 * The Websocket subprotocol "channel.k8s.io" prepends each binary message
+			 * with a byte indicating the channel number (zero indexed) the message was
+			 * sent on. Messages in both directions should prefix their messages with
+			 * this channel byte. When used for remote execution, the channel numbers
+			 * are by convention defined to match the POSIX file-descriptors assigned
+			 * to STDIN, STDOUT, and STDERR (0, 1, and 2). No other conversion is
+			 * performed on the raw subprotocol - writes are sent as they are received
+			 * by the server.
+			 */
+
+			int channel = message.byteStream().read();
+			String msg = message.string();
+			deliver( channel, msg );
+		}
+
+	}
+
+}

--- a/src/main/java/com/openshift/internal/restclient/capability/CapabilityInitializer.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/CapabilityInitializer.java
@@ -22,6 +22,7 @@ import com.openshift.internal.restclient.capability.resources.ImageStreamImportC
 import com.openshift.internal.restclient.capability.resources.OpenShiftBinaryPodLogRetrieval;
 import com.openshift.internal.restclient.capability.resources.OpenShiftBinaryPortForwarding;
 import com.openshift.internal.restclient.capability.resources.OpenShiftBinaryRSync;
+import com.openshift.internal.restclient.api.capabilities.PodExec;
 import com.openshift.internal.restclient.capability.resources.PodLogRetrievalAsync;
 import com.openshift.internal.restclient.capability.resources.ProjectTemplateListCapability;
 import com.openshift.internal.restclient.capability.resources.ProjectTemplateProcessing;
@@ -42,6 +43,7 @@ import com.openshift.restclient.capability.resources.IDeployCapability;
 import com.openshift.restclient.capability.resources.IDeploymentConfigTraceability;
 import com.openshift.restclient.capability.resources.IDeploymentTraceability;
 import com.openshift.restclient.capability.resources.IImageStreamImportCapability;
+import com.openshift.restclient.api.capabilities.IPodExec;
 import com.openshift.restclient.capability.resources.IPodLogRetrieval;
 import com.openshift.restclient.capability.resources.IPodLogRetrievalAsync;
 import com.openshift.restclient.capability.resources.IPortForwardable;
@@ -110,6 +112,7 @@ public class CapabilityInitializer {
 		initializeCapability(capabilities, IPortForwardable.class, new OpenShiftBinaryPortForwarding(pod, client));
 		initializeCapability(capabilities, IPodLogRetrieval.class, new OpenShiftBinaryPodLogRetrieval(pod, client));
 		initializeCapability(capabilities, IPodLogRetrievalAsync.class, new PodLogRetrievalAsync(pod, client));
+		initializeCapability(capabilities, IPodExec.class, new PodExec(pod, client));
 		initializeCapability(capabilities, IRSyncable.class, new OpenShiftBinaryRSync(client));
 	}
 

--- a/src/main/java/com/openshift/restclient/api/capabilities/IPodExec.java
+++ b/src/main/java/com/openshift/restclient/api/capabilities/IPodExec.java
@@ -1,0 +1,150 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package com.openshift.restclient.api.capabilities;
+
+import com.openshift.restclient.capability.ICapability;
+import com.openshift.restclient.capability.IStoppable;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Runs container exec
+ */
+public interface IPodExec extends ICapability{
+
+	/**
+	 * Execute a command on a named container in this pod
+	 * @param listener Listener for command output
+	 * @param options Options for the exec
+	 * @param commands A command to run and any arguments
+	 * @return A Handle to allow termination of the connection
+	 */
+	IStoppable start( IPodExecOutputListener listener, Options options, String... commands );
+
+
+	/**
+	 * A callback for exec output
+	 *
+	 */
+	interface IPodExecOutputListener{
+
+		/**
+		 * Callback received on initial connection
+		 */
+		void onOpen();
+
+		/**
+		 * Exec received stdout message
+		 * @param message
+		 */
+		void onStdOut(String message);
+
+		/**
+		 * Exec received stderr message
+		 * @param message
+		 */
+		void onStdErr(String message);
+
+		/**
+		 * Exec (channel 3) error message
+		 * @param message
+		 */
+		void onExecErr(String message);
+
+		/**
+		 * Called by lower level errors
+		 * @param e Exception causing failure
+		 */
+		void onFailure(IOException e);
+
+		/**
+		 * Callback received when the connection
+		 * to the pod is terminated from the server-side
+		 * @param code       a valid http response code
+		 * @param reason     a reason for termination, may be null
+		 */
+		void onClose(int code, String reason);
+	}
+
+	/**
+	 * Options for exec
+	 */
+	class Options{
+
+		public static final String CONTAINER = "container";
+		public static final String STDOUT = "stdout";
+		public static final String STDERR = "stderr";
+		private Map<String, String> options = new HashMap<>();
+		private Map<String, String> secondaries = new HashMap<>();
+
+		private Options storeSecondary(String key, Object v ) {
+			secondaries.put( key, v.toString() );
+			return this;
+		}
+
+		/**
+		 * The container from which to retrieve logs
+		 * @param container
+		 * @return
+		 */
+		public Options container(String container) {
+			return storeSecondary(CONTAINER, container);
+		}
+
+		/**
+		 * Enable stdout
+		 * @param value
+		 * @return
+		 */
+		public Options stdOut(boolean value) {
+			return storeSecondary(STDOUT, value);
+		}
+
+		/**
+		 * Enable stderr
+		 * @param value
+		 * @return
+		 */
+		public Options stdErr(boolean value) {
+			return storeSecondary(STDERR, value);
+		}
+
+		/**
+		 * Add an option that is not explicitly
+		 * defined.  These will override any
+		 * explicit options if there are collisions
+		 *
+		 * @param name
+		 * @param value
+		 * @return
+		 */
+		public Options parameter(String name, String value) {
+			options.put(name, value);
+			return this;
+		}
+
+		/**
+		 * The collective options
+		 * @return a map of all the options
+		 */
+		public Map<String, String> getMap(){
+			HashMap combined = new HashMap<>(secondaries);
+			combined.putAll(options);
+			return Collections.unmodifiableMap(combined);
+		}
+	}
+
+
+
+}

--- a/src/main/java/com/openshift/restclient/capability/IStoppable.java
+++ b/src/main/java/com/openshift/restclient/capability/IStoppable.java
@@ -12,7 +12,7 @@ package com.openshift.restclient.capability;
 
 /**
  * Handle to something that can be
- * explicitily stopped or terminated
+ * explicitly stopped or terminated
  * 
  * @author jeff.cantrill
  *

--- a/src/test/java/com/openshift/internal/restclient/URLBuilderTest.java
+++ b/src/test/java/com/openshift/internal/restclient/URLBuilderTest.java
@@ -10,20 +10,21 @@
  ******************************************************************************/
 package com.openshift.internal.restclient;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-
+import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.model.IResource;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.openshift.restclient.ResourceKind;
-import com.openshift.restclient.model.IResource;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Jeff Cantrill
@@ -54,7 +55,20 @@ public class URLBuilderTest extends TypeMapperFixture{
 				.build().toString();
 		assertEquals(String.format("%s/api/v1/namespaces/foo/services?watch=true&resourceVersion=123&foo=bar", BASE_URL),url.toString());
 	}
-	
+
+	@Test
+	public void testDuplicateParameters() throws Exception {
+		IResource resource = givenAResource(ResourceKind.SERVICE, KubernetesAPIVersion.v1,"foo");
+		String url = builder.
+				resource(resource)
+				.watch()
+				.addParmeter("resourceVersion", "123")
+				.addParmeter("x", "1")
+				.addParmeter("x", "2")
+				.build().toString();
+		assertEquals(String.format("%s/api/v1/namespaces/foo/services?watch=true&resourceVersion=123&x=1&x=2", BASE_URL),url.toString());
+	}
+
 	@Test
 	public void testBuildingURLForAProjectUsingResource() throws Exception {
 		IResource resource = givenAResource(ResourceKind.PROJECT, KubernetesAPIVersion.v1,"foo");

--- a/src/test/java/com/openshift/internal/restclient/api/capabilities/PodExecIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/api/capabilities/PodExecIntegrationTest.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.api.capabilities;
+
+import com.openshift.internal.restclient.IntegrationTestHelper;
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.api.capabilities.IPodExec;
+import com.openshift.restclient.capability.CapabilityVisitor;
+import com.openshift.restclient.capability.IStoppable;
+import com.openshift.restclient.model.IPod;
+import com.openshift.restclient.model.IResource;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+
+
+public class PodExecIntegrationTest {
+
+	private IntegrationTestHelper helper = new IntegrationTestHelper();
+	private Exception ex;
+	private IPod pod;
+
+	private static class TestExecListener implements IPodExec.IPodExecOutputListener {
+
+		private static final Logger LOG = LoggerFactory.getLogger(PodExecIntegrationTest.class);
+
+
+		public final CountDownLatch testDone = new CountDownLatch(1);
+		public final AtomicBoolean openCalled = new AtomicBoolean(false);
+		public final AtomicBoolean closeCalled = new AtomicBoolean(false);
+		public final AtomicBoolean failureCalled = new AtomicBoolean(false);
+		public final AtomicBoolean execErrCalled = new AtomicBoolean(false);
+		public final List<String> messages = Collections.synchronizedList( new ArrayList<String>() );
+
+		@Override
+		public void onOpen() {
+			assertTrue(openCalled.compareAndSet(false,true));
+		}
+
+		@Override
+		public void onStdOut(String message) {
+			LOG.debug( "onStdOut: " + message );
+			message = message.trim();
+			if ( message.isEmpty() == false ) { // Observing that actual output appears after empty newline
+				messages.add( PodExec.CHANNEL_STDOUT+message );
+			}
+		}
+
+		@Override
+		public void onStdErr(String message) {
+			LOG.debug( "onStdErr: " + message );
+			message = message.trim();
+			messages.add( PodExec.CHANNEL_STDERR+message );
+		}
+
+		@Override
+		public void onExecErr(String message) {
+			LOG.debug( "onExecError: " + message );
+			execErrCalled.set(true);
+			message = message.trim();
+			messages.add( PodExec.CHANNEL_EXECERR+message );
+		}
+
+		@Override
+		public void onClose(int code, String reason) {
+			assertTrue(closeCalled.compareAndSet(false,true));
+			testDone.countDown();
+		}
+
+		@Override
+		public void onFailure(IOException e) {
+			failureCalled.set(true);
+			LOG.error( "Potentially expected error occurred", e );
+			testDone.countDown();
+		}
+
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		IClient client = helper.createClientForBasicAuth();
+		List<IResource> pods = client.list(ResourceKind.POD, "default");
+		pod = (IPod) pods.stream().filter(p->p.getName().startsWith("docker-registry")).findFirst().orElse(null);
+		assertNotNull("Need a pod to continue the test. Expected to find the registry", pod);
+	}
+
+	@Test
+	public void testPodExec() throws Exception {
+		String[] echoCommand = { "echo", "a", "b", "c" };
+		TestExecListener echoListener = new TestExecListener();
+
+		pod.accept(new CapabilityVisitor<IPodExec, IStoppable>() {
+			@Override
+			public IStoppable visit(IPodExec capability) {
+				return capability.start( echoListener, null, echoCommand );
+			}
+		}, null);
+
+		echoListener.testDone.await( 60, TimeUnit.SECONDS );
+		assertTrue( echoListener.openCalled.get() );
+		assertTrue( echoListener.closeCalled.get() );
+		assertTrue( !echoListener.failureCalled.get() );
+		assertTrue( !echoListener.execErrCalled.get() );
+		assertEquals( 1, echoListener.messages.size() );
+		assertEquals( "1a b c", echoListener.messages.get(0));
+	}
+
+	@Test
+	public void testPodExecWithContainerSpecified() throws Exception {
+		String[] echoCommand = { "echo", "a", "b", "c" };
+		TestExecListener echoListener = new TestExecListener();
+
+		final String container = pod.getContainers().iterator().next().getName();
+		IPodExec.Options options = new IPodExec.Options();
+		options.container( container );
+
+		pod.accept(new CapabilityVisitor<IPodExec, IStoppable>() {
+			@Override
+			public IStoppable visit(IPodExec capability) {
+				return capability.start( echoListener, options, echoCommand );
+			}
+		}, null);
+
+		echoListener.testDone.await( 60, TimeUnit.SECONDS );
+		assertTrue( echoListener.openCalled.get() );
+		assertTrue( echoListener.closeCalled.get() );
+		assertTrue( !echoListener.failureCalled.get() );
+		assertTrue( !echoListener.execErrCalled.get() );
+		assertEquals( 1, echoListener.messages.size() );
+		assertEquals( "1a b c", echoListener.messages.get(0));
+	}
+
+	@Test
+	public void testCommandNotFound() throws Exception {
+		String[] badCommand = { "/bin/doesnotexist" };
+		TestExecListener badListener = new TestExecListener();
+
+		pod.accept(new CapabilityVisitor<IPodExec, IStoppable>() {
+			@Override
+			public IStoppable visit(IPodExec capability) {
+				return capability.start( badListener, null, badCommand );
+			}
+		}, null);
+
+		badListener.testDone.await( 60, TimeUnit.SECONDS );
+		assertTrue( badListener.openCalled.get() );
+		assertTrue( badListener.closeCalled.get() );
+		assertTrue( badListener.execErrCalled.get() );
+		// both execErr and stdErr will be called
+		assertEquals( 2, badListener.messages.size() );
+	}
+
+	@Test
+	public void testPodExecStop() throws Exception {
+		String[] longCommand = { "sleep", "500" };
+		TestExecListener longListener = new TestExecListener();
+
+		IStoppable stopLong = pod.accept(new CapabilityVisitor<IPodExec, IStoppable>() {
+			@Override
+			public IStoppable visit(IPodExec capability) {
+				return capability.start( longListener, null, longCommand );
+			}
+		}, null);
+
+		// Trigger a cancel on the web socket before long delay can complete
+		stopLong.stop();
+		longListener.testDone.await( 60, TimeUnit.SECONDS );
+		assertTrue( longListener.failureCalled.get() );
+	}
+
+	@Test
+	public void testContainerDoesNotExist() throws Exception {
+		String[] dateCommand = { "date" };
+		TestExecListener dateListener = new TestExecListener();
+		IPodExec.Options options = new IPodExec.Options();
+		options.container( "will-not-exist-in-docker-registry-pod" );
+
+		pod.accept(new CapabilityVisitor<IPodExec, IStoppable>() {
+			@Override
+			public IStoppable visit(IPodExec capability) {
+				return capability.start( dateListener, options, dateCommand );
+			}
+		}, null);
+
+		dateListener.testDone.await( 60, TimeUnit.SECONDS );
+		assertTrue( dateListener.failureCalled.get() );
+	}
+
+
+}

--- a/src/test/java/com/openshift/internal/restclient/api/capabilities/PodExecTest.java
+++ b/src/test/java/com/openshift/internal/restclient/api/capabilities/PodExecTest.java
@@ -1,0 +1,115 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package com.openshift.internal.restclient.api.capabilities;
+
+import com.openshift.internal.restclient.DefaultClient;
+import com.openshift.internal.restclient.TypeMapperFixture;
+import com.openshift.internal.restclient.capability.resources.PodLogRetrievalAsync;
+import com.openshift.restclient.IApiTypeMapper;
+import com.openshift.restclient.api.capabilities.IPodExec;
+import com.openshift.restclient.model.IPod;
+import com.openshift.restclient.model.MocksFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PodExecTest extends TypeMapperFixture {
+
+	private DefaultClient client;
+	@Mock
+	private IApiTypeMapper mapper;
+	private PodLogRetrievalAsync capability;
+	private IPod pod;
+	private PodExec.ExecOutputListenerAdapter adapter;
+
+	@Mock
+	private IPodExec.IPodExecOutputListener listener;
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		client = new DefaultClient(null, getHttpClient(), null, getApiTypeMapper(), null);
+		pod = new MocksFactory().mock(IPod.class);
+		capability = new PodLogRetrievalAsync(pod, client);
+		adapter = new PodExec.ExecOutputListenerAdapter(null, listener);
+	}
+
+	@Test
+	public void testIsSupported() {
+		assertTrue("Exp. capability to be supported because the pod endpoint exists", capability.isSupported());
+	}
+
+	@Test
+	public void testIsNotSupportedWhenEndpointDoesNotExist() {
+		when(pod.getApiVersion()).thenReturn("somenoneexitentversion");
+		assertFalse("Exp. capability to not be supported because the pod endpoint does not exist exists", capability.isSupported());
+	}
+
+	@Test
+	public void testAdapterCallsListenerCycle() throws Exception {
+		adapter.onOpen(null, null);
+		adapter.onOpen(null, null);
+		verify(listener).onOpen();
+
+
+		adapter.deliver(PodExec.CHANNEL_STDOUT, "ImStdOut");
+		adapter.deliver(PodExec.CHANNEL_STDERR, "ImStdErr");
+		adapter.deliver(PodExec.CHANNEL_EXECERR, "ImExecErr");
+
+		verify(listener).onStdOut("ImStdOut");
+		verify(listener).onStdErr("ImStdErr");
+		verify(listener).onExecErr("ImExecErr");
+
+		adapter.onClose(1986, "the reason");
+		adapter.onClose(1986, "the reason");
+		verify(listener).onClose(1986, "the reason");
+	}
+
+	@Test
+	public void testExecOptions() throws Exception {
+		IPodExec.Options options = new IPodExec.Options();
+		assertEquals( 0, options.getMap().size() );
+
+		options.stdErr( false );
+		options.stdOut( false );
+		options.container( "test" );
+
+		assertEquals( 3, options.getMap().size() );
+
+		assertEquals( "false", options.getMap().get(IPodExec.Options.STDERR) );
+		assertEquals( "false", options.getMap().get(IPodExec.Options.STDOUT) );
+		assertEquals( "test", options.getMap().get(IPodExec.Options.CONTAINER) );
+
+		options.parameter( IPodExec.Options.STDERR, "true" );
+		options.parameter( IPodExec.Options.STDOUT, "true" );
+		options.parameter( IPodExec.Options.CONTAINER, "override" );
+
+		// Re-set these options to ensure they do not override parameter API
+		options.stdErr( false );
+		options.stdOut( false );
+		options.container( "test" );
+
+		assertEquals( "true", options.getMap().get(IPodExec.Options.STDERR) );
+		assertEquals( "true", options.getMap().get(IPodExec.Options.STDOUT) );
+		assertEquals( "override", options.getMap().get(IPodExec.Options.CONTAINER) );
+
+	}
+
+}


### PR DESCRIPTION
Feature to support exec function for OpenShift Jenkins plugin: https://trello.com/c/Yl4qomsw/878-5-additional-jenkins-plugin-enhancement-requests-from-github

fyi @gabemontero 

API use example:

```
            final IPodExec.Options options = new IPodExec.Options();
            options.stdErr(true);
            options.stdOut(true);
            options.container("ruby-hello-world");


            IPod pod = client.get("pods", "ruby-hello-world-1-hy2xq", "myproject");
            IStoppable v = pod.accept(new CapabilityVisitor<IPodExec, IStoppable>() {
                @Override
                public IStoppable visit(IPodExec capability) {
                    return capability.start( new IPodExec.IPodExecOutputListener() {
                        @Override
                        public void onOpen() {
                            System.out.println( "OPEN!" );
                        }

                        @Override
                        public void onStdOut(String message) {
                            System.out.println( "stdout: " + message );
                        }

                        @Override
                        public void onStdErr(String message) {
                            System.out.println( "stderr: " + message );
                        }

                        @Override
                        public void onExecErr(String message) {
                            System.out.println( "execerr: " + message );
                        }

                        @Override
                        public void onClose(int code, String reason) {
                            System.out.println( "CLOSE! [" + code + "]: " + reason  );
                        }

                        @Override
                        public void onFailure(IOException e) {
                            e.printStackTrace();
                        }

                    }, options, commands );
                }
            }, null);
```