### PR TITLE
Expose errors during async log retrieval

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/capability/resources/PodLogRetrievalAsync.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/resources/PodLogRetrievalAsync.java
@@ -10,16 +10,9 @@
  ******************************************************************************/
 package com.openshift.internal.restclient.capability.resources;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.openshift.internal.restclient.DefaultClient;
 import com.openshift.internal.restclient.URLBuilder;
+import com.openshift.internal.restclient.okhttp.ResponseCodeInterceptor;
 import com.openshift.internal.restclient.okhttp.WebSocketAdapter;
 import com.openshift.restclient.IApiTypeMapper;
 import com.openshift.restclient.IClient;
@@ -28,13 +21,19 @@ import com.openshift.restclient.capability.IStoppable;
 import com.openshift.restclient.capability.resources.IPodLogRetrievalAsync;
 import com.openshift.restclient.http.IHttpConstants;
 import com.openshift.restclient.model.IPod;
-
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.ws.WebSocket;
 import okhttp3.ws.WebSocketCall;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Impl of Pod log retrieval using websocket
@@ -91,7 +90,8 @@ public class PodLogRetrievalAsync implements IPodLogRetrievalAsync{
 				.addParameters(parameters)
 				.websocket();
 		Request request = client.newRequestBuilderTo(endpoint)
-				.build();	
+				.tag( new ResponseCodeInterceptor.Ignore(){} )
+				.build();
 		WebSocketCall call = WebSocketCall.create(okClient, request);
 		call.enqueue(adapter);
 		
@@ -139,6 +139,11 @@ public class PodLogRetrievalAsync implements IPodLogRetrievalAsync{
 		@Override
 		public void onMessage(ResponseBody message) throws IOException {
 			listener.onMessage(message.string());
+		}
+
+		@Override
+		public void onFailure(IOException e, Response response) {
+			listener.onFailure(e);
 		}
 		
 	}

--- a/src/main/java/com/openshift/restclient/capability/resources/IPodLogRetrievalAsync.java
+++ b/src/main/java/com/openshift/restclient/capability/resources/IPodLogRetrievalAsync.java
@@ -10,14 +10,14 @@
  ******************************************************************************/
 package com.openshift.restclient.capability.resources;
 
+import com.openshift.restclient.capability.ICapability;
+import com.openshift.restclient.capability.IStoppable;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.apache.commons.lang.StringUtils;
-
-import com.openshift.restclient.capability.ICapability;
-import com.openshift.restclient.capability.IStoppable;
 
 /**
  * Retrieve logs in an async call
@@ -67,6 +67,14 @@ public interface IPodLogRetrievalAsync extends ICapability{
 		 * @param reason     a reason for termination, may be null
 		 */
 		void onClose(int code, String reason);
+
+		/**
+		 * Callback received when the web socket connection
+		 * fails
+		 * @param e the exception which occurred
+		 */
+		void onFailure(IOException e);
+
 	}
 	
 	/**

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/PodLogRetrievalAsyncIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/PodLogRetrievalAsyncIntegrationTest.java
@@ -10,16 +10,6 @@
  ******************************************************************************/
 package com.openshift.internal.restclient.capability.resources;
 
-import static org.junit.Assert.assertNotNull;
-
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.openshift.internal.restclient.DefaultClient;
 import com.openshift.internal.restclient.IntegrationTestHelper;
 import com.openshift.restclient.ResourceKind;
@@ -30,6 +20,17 @@ import com.openshift.restclient.capability.resources.IPodLogRetrievalAsync.IPodL
 import com.openshift.restclient.capability.resources.IPodLogRetrievalAsync.Options;
 import com.openshift.restclient.model.IPod;
 import com.openshift.restclient.model.IResource;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * 
@@ -76,6 +77,13 @@ public class PodLogRetrievalAsyncIntegrationTest {
 						LOG.debug("onClose code:{} reason:{}", code, reason);
 						latch.countDown();
 					}
+
+					@Override
+					public void onFailure(IOException e) {
+						LOG.error( "Unexpected websocket failure", e );
+						fail( "Unexpected websocket failure" );
+					}
+
 				}, new Options()
 						.follow()
 						.container(container));


### PR DESCRIPTION
Exceptions when attempting to retrieve logs asynchronously from pods are currently swallowed in the okhttp dispatcher thread. Perhaps we could introduce a model similar to #220  ?

fyi @gabemontero 