### PR TITLE
add service account to replication controller

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/model/ReplicationController.java
+++ b/src/main/java/com/openshift/internal/restclient/model/ReplicationController.java
@@ -51,6 +51,7 @@ public class ReplicationController extends KubernetesResource implements IReplic
 	protected static final String SPEC_REPLICAS = "spec.replicas";
 	protected static final String SPEC_SELECTOR = "spec.selector";
 	protected static final String STATUS_REPLICA = "status.replicas";
+	protected static final String SERVICEACCOUNTNAME = "spec.template.spec.serviceAccountName";
 
 	protected static final String IMAGE = "image";
 	protected static final String ENV = "env";
@@ -364,4 +365,14 @@ public class ReplicationController extends KubernetesResource implements IReplic
 		}
 		volList.add(ModelNode.fromJSONString(volumeSource.toJSONString()));
 	}
+
+    @Override
+    public void setServiceAccountName(String serviceAccountName) {
+        set(SERVICEACCOUNTNAME, serviceAccountName);
+    }
+
+    @Override
+    public String getServiceAccountName() {
+        return asString(SERVICEACCOUNTNAME);
+    }
 }

--- a/src/main/java/com/openshift/restclient/model/IReplicationController.java
+++ b/src/main/java/com/openshift/restclient/model/IReplicationController.java
@@ -195,4 +195,17 @@ public interface IReplicationController  extends IResource{
 	void setVolumes(Set<IVolumeSource> volumes);
 
 	void setContainers(Collection<IContainer> containers);
+	
+	/**
+     * Sets the service account to run this replication controller under. 
+     *
+     * @param volumes The service account to assign to the spec.
+     */
+	void setServiceAccountName(String serviceAccount);
+    
+    /**
+     * Retrieves the service account used by the controller
+     * @return
+     */
+    String getServiceAccountName();
 }

--- a/src/test/java/com/openshift/internal/restclient/model/v1/ReplicationControllerTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/ReplicationControllerTest.java
@@ -177,6 +177,17 @@ public class ReplicationControllerTest {
 	}
 	
 	@Test
+    public void getServiceAccountName() {
+        assertEquals("dbServiceAccountName", rc.getServiceAccountName());
+    }
+	
+	@Test
+    public void setServiceAccountName() {
+	    rc.setServiceAccountName("newDBServiceAccountName");
+        assertEquals("newDBServiceAccountName", rc.getServiceAccountName());
+    }
+	
+	@Test
 	public void getDesiredReplicaCount(){
 		assertEquals(1, rc.getDesiredReplicaCount());
 	}

--- a/src/test/resources/samples/openshift3/v1_replication_controller.json
+++ b/src/test/resources/samples/openshift3/v1_replication_controller.json
@@ -77,7 +77,8 @@
                     }
                 ],
                 "restartPolicy": "Always",
-                "dnsPolicy": "ClusterFirst"
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "dbServiceAccountName",
             }
         }
     },


### PR DESCRIPTION
add service account to replication controller

Ref: https://docs.openshift.com/enterprise/3.2/dev_guide/deployments.html#run-pod-with-different-service-account

