### PR TITLE
Fixed NPE

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/okhttp/ResponseCodeInterceptor.java
+++ b/src/main/java/com/openshift/internal/restclient/okhttp/ResponseCodeInterceptor.java
@@ -86,7 +86,7 @@ public class ResponseCodeInterceptor implements Interceptor, IHttpConstants {
 	}
 	
 	public static IStatus getStatus(String response) {
-		if(response.startsWith("{")) {
+		if(response != null && response.startsWith("{")) {
 			return new Status(response);
 		}
 		return null;


### PR DESCRIPTION
WatchClient.watch() passes null as the response, which resulted in an NPE