### PR TITLE
JBIDE-23463 Properties: Build pod has state of exit code 0 instead of correct status completed

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/model/Pod.java
+++ b/src/main/java/com/openshift/internal/restclient/model/Pod.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -44,11 +45,11 @@ public class Pod extends KubernetesResource implements IPod {
 	private static final String POD_STATUS_CONTAINER_STATUSES = "status.containerStatuses";
 	
 	// container reasons fields and corresponding status prefixes
-	private static final Map<String, String> POD_STATUS_CONTAINER_STATES = new HashMap<String, String>() {{
-		put("state.waiting.reason", "");
-		put("state.terminated.reason", "");
-		put("state.terminated.signal", "Signal: ");
-		put("state.terminated.exitCode", "Exit Code: ");		
+	private static final List<String[]> POD_STATUS_CONTAINER_STATES = new ArrayList<String[]>() {{
+		add(new String[]{"state.waiting.reason", ""});
+		add(new String[]{"state.terminated.reason", ""});
+		add(new String[]{"state.terminated.signal", "Signal: "});
+		add(new String[]{"state.terminated.exitCode", "Exit Code: "});
 	}};
 
 	public Pod(ModelNode node, IClient client, Map<String, String []> propertyKeys) {
@@ -100,10 +101,12 @@ public class Pod extends KubernetesResource implements IPod {
 	}
 	
 	private String getContainerStatusStringIfExist(ModelNode containerStatus) {
-		for (String path: POD_STATUS_CONTAINER_STATES.keySet()) {
+		for (String[] pathAndLabel: POD_STATUS_CONTAINER_STATES) {
+			String path = pathAndLabel[0];
 			String statusPostfix = JBossDmrExtentions.asString(containerStatus, null, path);
 			if (StringUtils.isNotEmpty(statusPostfix)) {
-				return POD_STATUS_CONTAINER_STATES.get(path) + statusPostfix; 
+				String label = pathAndLabel[1];
+				return label + statusPostfix;
 			}	
 		}
 		return null;

--- a/src/test/java/com/openshift/internal/restclient/model/v1/PodTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/PodTest.java
@@ -81,6 +81,19 @@ public class PodTest {
 		assertEquals(pod.getStatus(), "ReasonToTerminate");
 	}
 	
+	/**
+	 * Check that if both reason and exit code are set, status returns the reason.
+	 */
+	@Test
+	public void testGetStatusTerminateReasonAndExit() {
+		ModelNode node = new ModelNode();
+		node.get("reason").set("ReasonToTerminate");
+		node.get("exitCode").set("Let's go! Time to exit!");
+		((Pod)pod).getNode().get("status", "containerStatuses").asList().get(0).get("state")
+			.set("terminated", node);
+		assertEquals(pod.getStatus(), "ReasonToTerminate");
+	}
+
 	@Test
 	public void testGetStatusTerminatedSignal() {
 		((Pod)pod).getNode().get("status", "containerStatuses").asList().get(0).get("state")
@@ -88,6 +101,19 @@ public class PodTest {
 		assertEquals(pod.getStatus(), "Signal: Alarm! Terminate!");
 	}
 	
+	/**
+	 * Check that if both signal and exit code are set, status returns the signal.
+	 */
+	@Test
+	public void testGetStatusTerminatedSignalAndExit() {
+		ModelNode node = new ModelNode();
+		node.get("signal").set("Alarm! Terminate!");
+		node.get("exitCode").set("Let's go! Time to exit!");
+		((Pod)pod).getNode().get("status", "containerStatuses").asList().get(0).get("state")
+			.set("terminated", node);
+		assertEquals(pod.getStatus(), "Signal: Alarm! Terminate!");
+	}
+
 	@Test
 	public void testGetStatusTerminatedExit() {
 		((Pod)pod).getNode().get("status", "containerStatuses").asList().get(0).get("state")


### PR DESCRIPTION
Logic of Pod.getStatus() is fixed to copy that of
resources.js .filter('podStatus')