### PR TITLE
adjust to removal of service.spec.portalIP

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/model/Service.java
+++ b/src/main/java/com/openshift/internal/restclient/model/Service.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
 
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.ResourceKind;
@@ -136,9 +135,18 @@ public class Service extends KubernetesResource implements IService {
 		return port != null ? port.getTargetPort() : "0";
 	}
 
-	@Override
+	@Override @Deprecated
 	public String getPortalIP() {
-		return asString("spec.portalIP");
+		String tmp = asString("spec.portalIP");
+		if (StringUtils.isBlank(tmp)) {
+		    tmp = getClusterIP();
+		}
+		return tmp;
+	}
+	
+	@Override
+	public String getClusterIP() {
+	    return asString("spec.clusterIP");
 	}
 
 	@Override

--- a/src/main/java/com/openshift/restclient/model/IService.java
+++ b/src/main/java/com/openshift/restclient/model/IService.java
@@ -75,7 +75,14 @@ public interface IService extends IResource{
 	 * Returns the IP of the service.
 	 * @return
 	 */
+	@Deprecated
 	String getPortalIP();
+	
+	/**
+	 * Returns the IP of the service.
+	 * @return
+	 */
+	String getClusterIP();
 	
 	/**
 	 * Retrieves the pods for this service

--- a/src/test/java/com/openshift/internal/restclient/model/v1/ServiceTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/ServiceTest.java
@@ -49,6 +49,11 @@ public class ServiceTest{
 		assertEquals("172.30.57.114", service.getPortalIP());
 	}
 
+    @Test
+    public void testGetClusterIP() {
+        assertEquals("172.30.57.114", service.getClusterIP());
+    }
+
 	@Test
 	public void testGetTargetPort() {
 		assertEquals("3306", service.getTargetPort());

--- a/src/test/resources/samples/openshift3/v1_service.json
+++ b/src/test/resources/samples/openshift3/v1_service.json
@@ -33,7 +33,7 @@
         "selector": {
             "name": "database"
         },
-        "portalIP": "172.30.57.114",
+        "clusterIP": "172.30.57.114",
         "type": "ClusterIP",
         "sessionAffinity": "None"
     },


### PR DESCRIPTION
@jcantrill PTAL

Turns out that with https://github.com/openshift/origin/pull/10777 the field service.spec.portalID has been removed.  QE just uncovered it via https://github.com/openshift/jenkins-plugin/issues/122 (where an unlucky set of circumstances allowed it to slip through the jenkins-plugin's automated tests.