### PR TITLE
allow use of okhttp3 default hostname verifier with cert callback

### DIFF
--- a/src/main/java/com/openshift/restclient/ClientBuilder.java
+++ b/src/main/java/com/openshift/restclient/ClientBuilder.java
@@ -46,6 +46,7 @@ public class ClientBuilder {
 	
 	private String baseUrl;
 	private ISSLCertificateCallback sslCertificateCallback = new NoopSSLCertificateCallback();
+	private boolean sslCertCallbackWithDefaultHostnameVerifier = false;
 	private X509Certificate certificate;
 	private String certificateAlias;
 	private IResourceFactory resourceFactory;
@@ -75,6 +76,11 @@ public class ClientBuilder {
 	public ClientBuilder sslCertificateCallback(ISSLCertificateCallback callback) {
 		this.sslCertificateCallback = callback == null ? new NoopSSLCertificateCallback() : callback;
 		return this;
+	}
+	
+	public ClientBuilder sslCertCallbackWithDefaultHostnameVerifier(boolean b) {
+	    this.sslCertCallbackWithDefaultHostnameVerifier = b;
+	    return this;
 	}
 	
 	public ClientBuilder sslCertificate(String alias, X509Certificate cert) {
@@ -190,9 +196,11 @@ public class ClientBuilder {
 				.readTimeout(readTimeout, readTimeoutUnit)
 				.writeTimeout(writeTimeout, writeTimeoutUnit)
 				.connectTimeout(connectTimeout, connectTimeoutUnit)
-				.hostnameVerifier(this.sslCertificateCallback)
 				.sslSocketFactory(sslContext.getSocketFactory(), trustManager);
 
+			if (!this.sslCertCallbackWithDefaultHostnameVerifier)
+			    builder.hostnameVerifier(sslCertificateCallback);
+			
 			if (proxyAuthenticator != null) {
 				builder.proxyAuthenticator(proxyAuthenticator);
 			}


### PR DESCRIPTION
@jcantrill PTAL

for the jenkins plugin, we are better served to use the default hostname provider supplied by okhttp3 (i.e. `ISSLCertificateCallback.allowHostname`), but we still want supply logic in the `allowCertificate` path.

All this stems from the discussions with Clayton in https://github.com/openshift/origin/issues/12476