### PR TITLE
jbide-23862: User should be able to see what OpenShift version a connection is

### DIFF
--- a/src/main/java/com/openshift/restclient/IClient.java
+++ b/src/main/java/com/openshift/restclient/IClient.java
@@ -272,6 +272,18 @@ public interface IClient extends ICapable, Cloneable {
 	 * @throws OpenShiftException
 	 */
 	String getServerReadyStatus();
+	
+	/**
+	 * Query the server to determine the Openshift version
+	 * @return
+	 */
+	String getOpenshiftMasterVersion();
+	
+	/**
+	 * Query the server to determine the Kubernetes version
+	 * @return
+	 */
+	String getKubernetesMasterVersion();
 
 	IClient clone();
 }

--- a/src/test/java/com/openshift/internal/restclient/DefaultClientTest.java
+++ b/src/test/java/com/openshift/internal/restclient/DefaultClientTest.java
@@ -92,7 +92,7 @@ public class DefaultClientTest extends TypeMapperFixture{
 
 	
 	private DefaultClient givenClient(URL baseUrl, String token, String user) {
-		DefaultClient client = new DefaultClient(baseUrl, null, null, null, new AuthorizationContext(token,user,null));
+		DefaultClient client = new DefaultClient(baseUrl, getHttpClient(), null, null, new AuthorizationContext(token,user,null));
 		return client;
 	}
 

--- a/src/test/java/com/openshift/internal/restclient/TypeMapperFixture.java
+++ b/src/test/java/com/openshift/internal/restclient/TypeMapperFixture.java
@@ -62,6 +62,8 @@ public class TypeMapperFixture {
 		client.whenRequestTo(base + "/api/v1").thenReturn(responseOf(Samples.GROUP_ENDPONT_API_V1.getContentAsString()));
 		client.whenRequestTo(base + "/oapi/v1").thenReturn(responseOf(Samples.GROUP_ENDPONT_OAPI_V1.getContentAsString()));
 		client.whenRequestTo(base + "/apis/extensions/v1beta1").thenReturn(responseOf(Samples.GROUP_ENDPONT_APIS_EXTENSIONS.getContentAsString()));
+		client.whenRequestTo(base + "/version").thenReturn(responseOf(Samples.KUBERNETES_VERSION.getContentAsString()));
+		client.whenRequestTo(base + "/version/openshift").thenReturn(responseOf(Samples.OPENSHIFT_VERSION.getContentAsString()));
 		mapper = new ApiTypeMapper(base, client);
 	}
 	

--- a/src/test/java/com/openshift/restclient/utils/Samples.java
+++ b/src/test/java/com/openshift/restclient/utils/Samples.java
@@ -19,6 +19,9 @@ import org.apache.commons.io.IOUtils;
  * @author Jeff Cantrill
  */
 public enum Samples {
+	
+	OPENSHIFT_VERSION("openshift3/api_openshift_version.json"),
+	KUBERNETES_VERSION("openshift3/api_kubernetes_version.json"),
 
 	GROUP_ENDPONT_API_V1("openshift3/api_v1_endpoint.json"),
 	GROUP_ENDPONT_OAPI_V1("openshift3/oapi_v1_endpoint.json"),

--- a/src/test/resources/samples/openshift3/api_kubernetes_version.json
+++ b/src/test/resources/samples/openshift3/api_kubernetes_version.json
@@ -1,0 +1,11 @@
+{
+  "major": "1",
+  "minor": "6",
+  "gitVersion": "v1.6.1+5115d708d7",
+  "gitCommit": "010d313",
+  "gitTreeState": "clean",
+  "buildDate": "2017-06-07T23:14:34Z",
+  "goVersion": "go1.7.5",
+  "compiler": "gc",
+  "platform": "linux/amd64"
+}

--- a/src/test/resources/samples/openshift3/api_openshift_version.json
+++ b/src/test/resources/samples/openshift3/api_openshift_version.json
@@ -1,0 +1,7 @@
+{
+  "major": "3",
+  "minor": "6+",
+  "gitCommit": "3c221d5",
+  "gitVersion": "v3.6.0-alpha.2+3c221d5",
+  "buildDate": "2017-06-07T23:14:34Z"
+}


### PR DESCRIPTION
@jcantrill @jeffmaury @adietish please, take a look. I've changed the api of the `IClient`. Is it ok? Do you know anybody else who uses this rest client, except us? Will it be critical for them? If yes, there is no problem to leave `IClient` as it is and add the new methods only to the `DefaultClient` class 