### PR TITLE
pod exec needs stdOut/stdErr set for 3.7 servers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<!-- Artifact Information -->
 	<groupId>com.openshift</groupId>
 	<artifactId>openshift-restclient-java</artifactId>
-	<version>5.8.0.FINAL</version>
+	<version>5.9.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>OpenShift Java REST Client</name>
 	<url>http://openshift.redhat.com</url>

--- a/src/main/java/com/openshift/internal/restclient/api/capabilities/PodExec.java
+++ b/src/main/java/com/openshift/internal/restclient/api/capabilities/PodExec.java
@@ -71,6 +71,13 @@ public class PodExec extends AbstractCapability implements IPodExec {
 		if ( options == null ) {
 			options = new Options();
 		}
+		
+		/*
+         with 3.7 per https://github.com/openshift/origin/issues/15330, 3.6 was evidently broke in allowing stdErr/stdOut to not be set; need to set stdout/stderr to true
+		 */
+		options.stdErr(true);
+		options.stdOut(true);
+		
 
 		Map<String,String> parameters = options.getMap();
 


### PR DESCRIPTION
first step in fixing https://github.com/openshift/origin/issues/15330

this allowed my to exec into a pod via the openshift pipeline plugin for jenkins and the openshift-restclient-server against a 3.7 server.

it also works against 3.6 rc0

@jcantrill ptal

@deads2k fyi ... also, so you know, after this gets pushed to the maven repo, there will be subsequent steps to update the plugin and image before the extended test noted in https://github.com/openshift/origin/issues/15330 passes again and we can close it out