### PR TITLE
bump to 5.9.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<!-- Artifact Information -->
 	<groupId>com.openshift</groupId>
 	<artifactId>openshift-restclient-java</artifactId>
-	<version>5.9.0.Final</version>
+	<version>5.9.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>OpenShift Java REST Client</name>
 	<url>http://openshift.redhat.com</url>


### PR DESCRIPTION
Late bumping current master to 5.9.1-SNAPSHOT. This is a late bump
since a first change was already done without bumping.
The erroneous final artifact wasn't released to maven repository
though so this duplication is limited to git.