### PR TITLE
revert PR 284

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,12 +131,12 @@
 		<dependency>
 		  <groupId>com.squareup.okhttp3</groupId>
 		  <artifactId>okhttp</artifactId>
-		  <version>3.8.1</version>
+		  <version>3.3.1</version>
 		</dependency>
 		<dependency>
 		  <groupId>com.squareup.okhttp3</groupId>
 		  <artifactId>okhttp-ws</artifactId>
-		  <version>3.4.2</version>
+		  <version>3.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.yaml</groupId>

--- a/src/test/java/com/openshift/internal/restclient/TypeMapperFixture.java
+++ b/src/test/java/com/openshift/internal/restclient/TypeMapperFixture.java
@@ -86,7 +86,6 @@ public class TypeMapperFixture {
 				.request(new Request.Builder().url("https://someurlfortesting").build())
 				.protocol(Protocol.HTTP_1_1)
 				.code(IHttpConstants.STATUS_OK)
-				.message("foo")
 				.body(ResponseBody.create(null, response))
 				.build();
 	}

--- a/src/test/java/com/openshift/internal/restclient/okhttp/WatchClientTest.java
+++ b/src/test/java/com/openshift/internal/restclient/okhttp/WatchClientTest.java
@@ -59,7 +59,6 @@ public class WatchClientTest {
 		Response.Builder responseBuilder = new Response.Builder();
 		responseBuilder.code(IHttpConstants.STATUS_OK)
 						.protocol(Protocol.HTTP_2)
-						.message("foo")
 						.request(new Request.Builder().url("http://localhost").build());
 		endpoint.onFailure(new ProtocolException(), responseBuilder.build());
 		verify(listener, never()).error(any());


### PR DESCRIPTION
@jcantrill - still not sure how my prior openshift testing missed this, but I've now confirmed that bumping okhttp is a more invasive change.

Specifically, it appears that okhttp-ws has been deprecated (see [1], [2]) and replaced with native websocket support in okhttp3 around v3.5

The internal classes that okhttp-ws depend on no longer exist (I finally figured this out when sorting thorugh  [3]).

While similar, the replacement classes were different enough that switching to the new APIs was not a quick fix for me (and I won't have the cycles to complete it on the side).

Hence, seemed more prudent to revert https://github.com/openshift/openshift-restclient-java/commit/1b29d03c88c8b13133ad5814a11f84b87a46ef2e

restclient integration tests look OK.

apologies for the churn ... assuming nobody else has seen this, and hopefully nobody has been negatively impacted, given the lack of issues, etc.

[1] https://github.com/csync/csync-android/issues/22
[2] https://medium.com/square-corner-blog/web-sockets-now-shipping-in-okhttp-3-5-463a9eec82d1
[3] https://github.com/openshift/jenkins-plugin/pull/149