### PR TITLE
Fix wrong number of argument for String.format

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/ApiTypeMapper.java
+++ b/src/main/java/com/openshift/internal/restclient/ApiTypeMapper.java
@@ -350,7 +350,7 @@ public class ApiTypeMapper implements IApiTypeMapper, ResourcePropertyKeys{
 		    if(apiGroupName == null) {
 		        return String.format("%s/%s/%s", prefix, version, name);
 		    }
-			return String.format("%s/%s/%s/%s/%s", prefix, apiGroupName, version, name);
+			return String.format("%s/%s/%s/%s", prefix, apiGroupName, version, name);
 		}
 
 		@Override


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>