### PR TITLE
#300 - Support spaces in paths to synchronize

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/capability/resources/AbstractOpenShiftBinaryCapability.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/resources/AbstractOpenShiftBinaryCapability.java
@@ -15,8 +15,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -66,7 +64,7 @@ public abstract class AbstractOpenShiftBinaryCapability implements IBinaryCapabi
 	 * Callback for building args to be sent to the {@code oc} command.
 	 * @return the String representation of all the arguments to use when running the {@code oc} command. 
 	 */
-	protected abstract String buildArgs(final List<OpenShiftBinaryOption> options);
+	protected abstract List<String> buildArgs(final List<OpenShiftBinaryOption> options);
 
 	protected IClient getClient() {
 		return client;
@@ -92,7 +90,7 @@ public abstract class AbstractOpenShiftBinaryCapability implements IBinaryCapabi
 	
 	protected String getUserFlag() {
 		final StringBuilder argBuilder = new StringBuilder();
-		argBuilder.append("--user=").append(client.getAuthorizationContext().getUserName()).append(" ");
+		argBuilder.append("--user=").append(client.getAuthorizationContext().getUserName());
 		return argBuilder.toString();
 	}
 
@@ -101,7 +99,7 @@ public abstract class AbstractOpenShiftBinaryCapability implements IBinaryCapabi
 	 */
 	protected String getServerFlag() {
 		final StringBuilder argBuilder = new StringBuilder();
-		argBuilder.append("--server=").append(client.getBaseURL()).append(" ");
+		argBuilder.append("--server=").append(client.getBaseURL());
 		return argBuilder.toString();
 	}
 
@@ -111,15 +109,14 @@ public abstract class AbstractOpenShiftBinaryCapability implements IBinaryCapabi
 	 */
 	protected String getTokenFlag() {
 		return new StringBuilder("--token=")
-			.append(client.getAuthorizationContext().getToken())
-			.append(" ").toString();
+			.append(client.getAuthorizationContext().getToken()).toString();
 	}
 	
 	/**
 	 * @return the command-line flag to use insecure connection (skip TLS verification)
 	 */
 	protected String getSkipTlsVerifyFlag() {
-		return "--insecure-skip-tls-verify=true ";
+		return "--insecure-skip-tls-verify=true";
 	}
 	
 	/**
@@ -130,21 +127,21 @@ public abstract class AbstractOpenShiftBinaryCapability implements IBinaryCapabi
 	protected String getGitFolderExclusionFlag() {
 		// no support for multiple exclusion, so excluding '.git' only for now
 		// see https://github.com/openshift/origin/issues/8223
-		return "--exclude='.git' ";
+		return "--exclude='.git'";
 	}
 	
 	/**
 	 * @return the command-line flag to avoid transferring permissions.
 	 */
 	protected String getNoPermsFlags() {
-		return "--no-perms=true ";
+		return "--no-perms=true";
 	}
 	
 	/**
 	 * @return the command-line flag to delete extraneous file from destination directories.
 	 */
 	protected String getDeleteFlags() {
-		return "--delete ";
+		return "--delete";
 	}
 
 	/**
@@ -173,33 +170,19 @@ public abstract class AbstractOpenShiftBinaryCapability implements IBinaryCapabi
 	
 	private ProcessBuilder initProcessBuilder(String location, final OpenShiftBinaryOption... options) {
 		List<String> args = new ArrayList<>();
-		ProcessBuilder builder = null;
+		args.add(location);
+		args.addAll(buildArgs(Arrays.asList(options)));
+		ProcessBuilder builder = new ProcessBuilder(args);
 		// the condition is made in order to solve mac problem 
 		// with launching binaries containing spaces in its path
 		// https://issues.jboss.org/browse/JBIDE-23862 - see the latest comments
-		if (IS_MAC) {
-			args.add(location);
-			args.addAll(splitTakingCareOfSpaceInsideQuotes(buildArgs(Arrays.asList(options))));
-			builder = new ProcessBuilder(args);
-		} else {
+		if (!IS_MAC) {
 			File oc = new File(location);
-			args.add(location);
-			args.addAll(splitTakingCareOfSpaceInsideQuotes(buildArgs(Arrays.asList(options))));
-			builder = new ProcessBuilder(args);
 			builder.directory(oc.getParentFile());
-		}		
+		}	
 		builder.environment().remove("KUBECONFIG");
 		LOG.debug("OpenShift binary args: {}", builder.command());
 		return builder;
-	}
-	
-	private List<String> splitTakingCareOfSpaceInsideQuotes(String str){
-		List<String> res = new ArrayList<>();
-		Matcher m = Pattern.compile("([^\"]\\S*|\".+?\")\\s*").matcher(str);
-		while (m.find()) {
-		    res.add(m.group(1)); 
-		}
-		return res;
 	}
 	
 	private void checkProcessIsAlive() throws IOException {

--- a/src/main/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryPodLogRetrieval.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryPodLogRetrieval.java
@@ -142,22 +142,25 @@ public class OpenShiftBinaryPodLogRetrieval implements IPodLogRetrieval {
 		}
 
 		@Override
-		protected String buildArgs(final List<OpenShiftBinaryOption> options) {
-			final StringBuilder argsBuilder = new StringBuilder();
-			argsBuilder.append("logs ");
+		protected List<String> buildArgs(final List<OpenShiftBinaryOption> options) {
+			List<String> args = new ArrayList<>();
+			args.add("logs");
 			if(options.contains(OpenShiftBinaryOption.SKIP_TLS_VERIFY)) {
-				argsBuilder.append(getSkipTlsVerifyFlag());
+				args.add(getSkipTlsVerifyFlag());
 			}
-			argsBuilder.append(getServerFlag()).append(" ")
-					.append(pod.getName()).append(" ").append("-n ").append(pod.getNamespace()).append(" ")
-					.append(getTokenFlag());
+			args.add(getServerFlag());
+			args.add(pod.getName());
+			args.add("-n");
+			args.add(pod.getNamespace());
+			args.add(getTokenFlag());
 			if(follow) {
-				argsBuilder.append(" -f ");
+				args.add("-f");
 			}
 			if(StringUtils.isNotBlank(container)) {
-				argsBuilder.append( " -c ").append(container);
+				args.add("-c");
+				args.add(container);
 			}
-			return argsBuilder.toString();
+			return args;
 		}
 	}
 	

--- a/src/main/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryPortForwarding.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryPortForwarding.java
@@ -76,18 +76,22 @@ public class OpenShiftBinaryPortForwarding extends AbstractOpenShiftBinaryCapabi
 	}
 
 	@Override
-	protected String buildArgs(final List<OpenShiftBinaryOption> options) {
-		final StringBuilder argBuilder = new StringBuilder();
-		argBuilder.append("port-forward ");
+	protected List<String> buildArgs(final List<OpenShiftBinaryOption> options) {
+		List<String> args = new ArrayList<>();
+		args.add("port-forward");
 		if(options.contains(OpenShiftBinaryOption.SKIP_TLS_VERIFY)) {
-			argBuilder.append(getSkipTlsVerifyFlag());
+			args.add(getSkipTlsVerifyFlag());
 		}
-		argBuilder.append(getServerFlag()).append(getTokenFlag()).append("-n ").append(pod.getNamespace()).append(" ")
-				.append("-p ").append(pod.getName()).append(" ");
+		args.add(getServerFlag());
+		args.add(getTokenFlag());
+		args.add("-n");
+		args.add(pod.getNamespace());
+		args.add("-p");
+		args.add(pod.getName());
 		for (PortPair pair : pairs) {
-			argBuilder.append(pair.getLocalPort()).append(":").append(pair.getRemotePort()).append(" ");
+			args.add(pair.getLocalPort() +":" +pair.getRemotePort());
 		}
-		return argBuilder.toString();
+		return args;
 	}
 	
 }

--- a/src/main/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryRSync.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryRSync.java
@@ -12,6 +12,7 @@ package com.openshift.internal.restclient.capability.resources;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -140,24 +141,27 @@ public class OpenShiftBinaryRSync extends AbstractOpenShiftBinaryCapability impl
 	}
 	
 	@Override
-	protected String buildArgs(final List<OpenShiftBinaryOption> options) {
-		final StringBuilder argsBuilder = new StringBuilder("rsync ");
-		argsBuilder.append(getTokenFlag()).append(getServerFlag());
+	protected List<String> buildArgs(final List<OpenShiftBinaryOption> options) {
+		List<String> args = new ArrayList<>();
+		args.add("rsync");
+		args.add(getTokenFlag());
+		args.add(getServerFlag());
+		
 		if(options.contains(OpenShiftBinaryOption.SKIP_TLS_VERIFY)) {
-			argsBuilder.append(getSkipTlsVerifyFlag());
+			args.add(getSkipTlsVerifyFlag());
 		}
 		if(options.contains(OpenShiftBinaryOption.EXCLUDE_GIT_FOLDER)) {
-			argsBuilder.append(getGitFolderExclusionFlag());
+			args.add(getGitFolderExclusionFlag());
 		}
 		if(options.contains(OpenShiftBinaryOption.NO_PERMS)) {
-			argsBuilder.append(getNoPermsFlags());
+			args.add(getNoPermsFlags());
 		}
 		if(options.contains(OpenShiftBinaryOption.DELETE)) {
-			argsBuilder.append(getDeleteFlags());
+			args.add(getDeleteFlags());
 		}
-		argsBuilder.append(source.getParameter()).append(" ")
-				.append(destination.getParameter());
-		return argsBuilder.toString();
+		args.addAll(source.getParameter());
+		args.addAll(destination.getParameter());
+		return args;
 	}
 	
 }

--- a/src/main/java/com/openshift/restclient/capability/resources/IRSyncable.java
+++ b/src/main/java/com/openshift/restclient/capability/resources/IRSyncable.java
@@ -53,7 +53,9 @@ public interface IRSyncable extends IBinaryCapability {
 			return new StringBuilder()
 					.append(pod.getName())
 					.append(POD_PATH_SEPARATOR)
+					.append("\"")
 					.append(super.getParameter())
+					.append("\"")
 					.append(" -n ")
 					.append(pod.getNamespace())
 					.toString();
@@ -66,7 +68,9 @@ public interface IRSyncable extends IBinaryCapability {
 					.append(NAMESPACE_POD_SEPARATOR)
 					.append(pod.getName())
 					.append(POD_PATH_SEPARATOR)
+					.append("\"")
 					.append(super.getParameter())
+					.append("\"")
 					.toString();
 		}
 
@@ -84,6 +88,11 @@ public interface IRSyncable extends IBinaryCapability {
 
 		public boolean isPod() {
 			return false;
+		}
+		
+		@Override
+		public String getParameter() {
+			return "\"" + super.getParameter() + "\"";
 		}
 	}
 

--- a/src/main/java/com/openshift/restclient/capability/resources/IRSyncable.java
+++ b/src/main/java/com/openshift/restclient/capability/resources/IRSyncable.java
@@ -11,6 +11,9 @@
 package com.openshift.restclient.capability.resources;
 
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import com.openshift.restclient.capability.IBinaryCapability;
 import com.openshift.restclient.model.IPod;
@@ -49,16 +52,12 @@ public interface IRSyncable extends IBinaryCapability {
 		}
 
 		@Override
-		public String getParameter() {
-			return new StringBuilder()
-					.append(pod.getName())
-					.append(POD_PATH_SEPARATOR)
-					.append("\"")
-					.append(super.getParameter())
-					.append("\"")
-					.append(" -n ")
-					.append(pod.getNamespace())
-					.toString();
+		public List<String> getParameter() {
+			List<String> res = new ArrayList<>();
+			res.add(pod.getName() + POD_PATH_SEPARATOR + "\"" + super.getLocation() + "\"");
+			res.add("-n");
+			res.add(pod.getNamespace());
+			return res;
 		}
 		
 		@Override
@@ -69,7 +68,7 @@ public interface IRSyncable extends IBinaryCapability {
 					.append(pod.getName())
 					.append(POD_PATH_SEPARATOR)
 					.append("\"")
-					.append(super.getParameter())
+					.append(super.getLocation())
 					.append("\"")
 					.toString();
 		}
@@ -91,8 +90,8 @@ public interface IRSyncable extends IBinaryCapability {
 		}
 		
 		@Override
-		public String getParameter() {
-			return "\"" + super.getParameter() + "\"";
+		public List<String> getParameter() {
+			return Arrays.asList("\"" + getLocation().replaceAll("\\\\", "/") + "\"");
 		}
 	}
 
@@ -104,12 +103,12 @@ public interface IRSyncable extends IBinaryCapability {
 			this.location = location;
 		}
 
-		public String getParameter() {
-			return location;
+		public List<String> getParameter() {
+			return Arrays.asList(getLocation());
 		}
 
 		public String getLocation() {
-			return getParameter();
+			return location;
 		}
 		
 		public abstract boolean isPod();

--- a/src/test/java/com/openshift/internal/restclient/api/capabilities/PodExecIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/api/capabilities/PodExecIntegrationTest.java
@@ -37,10 +37,9 @@ import static org.junit.Assert.*;
 public class PodExecIntegrationTest {
 
 	private IntegrationTestHelper helper = new IntegrationTestHelper();
-	private Exception ex;
 	private IPod pod;
 
-	private static class TestExecListener implements IPodExec.IPodExecOutputListener {
+	public static class TestExecListener implements IPodExec.IPodExecOutputListener {
 
 		private static final Logger LOG = LoggerFactory.getLogger(PodExecIntegrationTest.class);
 

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
@@ -10,6 +10,9 @@ package com.openshift.internal.restclient.capability.resources;
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -17,14 +20,11 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.fest.assertions.Assertions.*;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,13 +47,22 @@ import com.openshift.restclient.model.IResource;
  */
 public class OpenshiftBinaryRSyncRetrievalIntegrationTest {
 
+	private static final String TARGET_FOLDER_WITH_SPECIAL_CHARS = "/tmp/with sp@cé";
+	private static final String FILE_NAME_SPECIAL_CHARS = "test with spéci@l characters and spaces";
+	private static final String SOURCE_FOLDER_WITH_SPECIAL_CHARS = "with sp@cé in path";
+
+	private static final String NORMAL_TARGET_TMP = "/tmp";
+	private static final String NORMAL_FILE_NAME = "normalFileName";
+	private static final String NORMAL_FOLDER_NAME = "normalFolderName";
+
 	private static final Logger LOG = LoggerFactory.getLogger(OpenshiftBinaryRSyncRetrievalIntegrationTest.class); 
 	
 	private IntegrationTestHelper helper = new IntegrationTestHelper();
 	private IClient client;
-
-	private File localTempDir;
-
+	
+	@Rule
+	public TemporaryFolder tmpFolder = new TemporaryFolder();
+	
 	private Pod pod;
 
 	@Before
@@ -65,20 +74,38 @@ public class OpenshiftBinaryRSyncRetrievalIntegrationTest {
 		List<IResource> pods = client.list(ResourceKind.POD, "default");
 		pod = (Pod) pods.stream().filter(p->p.getName().startsWith("docker-registry")).findFirst().orElse(null);
 		assertNotNull("Did not find the registry pod to which to rsync", pod);
-
-		localTempDir = new File(FileUtils.getTempDirectory(), helper.generateNamespace());
-		localTempDir.deleteOnExit();
-		assertTrue(localTempDir.mkdirs());
 	}
 	
 	@Test
 	public void testRSyncLogRetrieval() throws IOException {
-		
-		final String targetDir = "/tmp";
-		// when
+		testRsyncLogRetrieval(NORMAL_FOLDER_NAME, NORMAL_FILE_NAME, NORMAL_TARGET_TMP);
+	}
+	
+	@Test
+	public void testRSyncLogRetrievalWithSpaceInFolderToSynchronize() throws IOException {
+		testRsyncLogRetrieval(SOURCE_FOLDER_WITH_SPECIAL_CHARS, NORMAL_FILE_NAME, NORMAL_TARGET_TMP);
+	}
+	
+	@Test
+	public void testRSyncLogRetrievalWithSpaceInFileToSynchronize() throws IOException {
+		testRsyncLogRetrieval(NORMAL_FOLDER_NAME, FILE_NAME_SPECIAL_CHARS, NORMAL_TARGET_TMP);
+	}
+	
+	@Test
+	public void testRSyncLogRetrievalWithSpaceInTargetDirectory() throws IOException {
+		testRsyncLogRetrieval(NORMAL_FOLDER_NAME, NORMAL_FILE_NAME, TARGET_FOLDER_WITH_SPECIAL_CHARS);
+	}
+	
+	@Test
+	public void testRSyncLogRetrievalWithSpaceEverywhere() throws IOException {
+		testRsyncLogRetrieval(SOURCE_FOLDER_WITH_SPECIAL_CHARS, FILE_NAME_SPECIAL_CHARS, TARGET_FOLDER_WITH_SPECIAL_CHARS);
+	}
+
+	protected void testRsyncLogRetrieval(String folderToSynchronizeName, String fileNameToSynchronize, String targetFolderPath) throws IOException {
+		File localTempDir = tmpFolder.newFolder(folderToSynchronizeName);
 		// create a dummy file to be sure there will be something to rsync
-		final String fileName = File.createTempFile("test", ".txt", localTempDir).getName()
-				;
+		final String fileName = File.createTempFile(fileNameToSynchronize, ".txt", localTempDir).getName();
+		
 		// run the rsync and collect the logs
 		 List<String> logs = pod.accept(new CapabilityVisitor<IRSyncable, List<String>>() {
 
@@ -86,13 +113,13 @@ public class OpenshiftBinaryRSyncRetrievalIntegrationTest {
 			public List<String> visit(IRSyncable cap) {
 				try {
 					final BufferedReader reader = new BufferedReader(new InputStreamReader(
-							cap.sync(new LocalPeer(localTempDir.getAbsolutePath()), new PodPeer(targetDir, pod), OpenShiftBinaryOption.SKIP_TLS_VERIFY)));
+							cap.sync(new LocalPeer(localTempDir.getAbsolutePath()), new PodPeer(targetFolderPath, pod), OpenShiftBinaryOption.SKIP_TLS_VERIFY)));
 					List<String> logs = IOUtils.readLines(reader);
 					// wait until end of 'rsync'
 					cap.await();
 					return logs;
 				} catch (Exception e) {
-					LOG.error("Exception rsycing to pod:",e);
+					LOG.error("Exception rsyncing to pod:",e);
 				}
 				return new ArrayList<>();
 			}

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
@@ -12,6 +12,7 @@ package com.openshift.internal.restclient.capability.resources;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -19,8 +20,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,14 +32,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.openshift.internal.restclient.IntegrationTestHelper;
+import com.openshift.internal.restclient.api.capabilities.PodExecIntegrationTest;
 import com.openshift.internal.restclient.model.Pod;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.api.capabilities.IPodExec;
 import com.openshift.restclient.capability.CapabilityVisitor;
 import com.openshift.restclient.capability.IBinaryCapability;
 import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
+import com.openshift.restclient.capability.IStoppable;
 import com.openshift.restclient.capability.resources.IRSyncable;
 import com.openshift.restclient.capability.resources.IRSyncable.LocalPeer;
+import com.openshift.restclient.capability.resources.IRSyncable.Peer;
 import com.openshift.restclient.capability.resources.IRSyncable.PodPeer;
 import com.openshift.restclient.model.IResource;
 
@@ -47,11 +54,11 @@ import com.openshift.restclient.model.IResource;
  */
 public class OpenshiftBinaryRSyncRetrievalIntegrationTest {
 
-	private static final String TARGET_FOLDER_WITH_SPECIAL_CHARS = "/tmp/with sp@cé";
+	private static final String TARGET_FOLDER_WITH_SPECIAL_CHARS = "/tmp/OpenshiftBinaryRSyncRetrievalIntegrationTest/with sp@cé/";
 	private static final String FILE_NAME_SPECIAL_CHARS = "test with spéci@l characters and spaces";
 	private static final String SOURCE_FOLDER_WITH_SPECIAL_CHARS = "with sp@cé in path";
 
-	private static final String NORMAL_TARGET_TMP = "/tmp";
+	private static final String NORMAL_TARGET_TMP = "/tmp/OpenshiftBinaryRSyncRetrievalIntegrationTest/withoutspace/";
 	private static final String NORMAL_FILE_NAME = "normalFileName";
 	private static final String NORMAL_FOLDER_NAME = "normalFolderName";
 
@@ -64,6 +71,7 @@ public class OpenshiftBinaryRSyncRetrievalIntegrationTest {
 	public TemporaryFolder tmpFolder = new TemporaryFolder();
 	
 	private Pod pod;
+	private String podFolderToClean = null;
 
 	@Before
 	public void setUp() throws Exception {
@@ -76,44 +84,89 @@ public class OpenshiftBinaryRSyncRetrievalIntegrationTest {
 		assertNotNull("Did not find the registry pod to which to rsync", pod);
 	}
 	
+	@After
+	public void tearDown() throws Exception {
+		if(podFolderToClean != null) {
+			execOnPod(new String[] {"rm", "-r",podFolderToClean});
+		}
+	}
+	
 	@Test
-	public void testRSyncLogRetrieval() throws IOException {
+	public void testRSyncLogRetrieval() throws Exception {
 		testRsyncLogRetrieval(NORMAL_FOLDER_NAME, NORMAL_FILE_NAME, NORMAL_TARGET_TMP);
 	}
 	
 	@Test
-	public void testRSyncLogRetrievalWithSpaceInFolderToSynchronize() throws IOException {
+	public void testRSyncLogRetrievalWithSpaceInFolderToSynchronize() throws Exception {
 		testRsyncLogRetrieval(SOURCE_FOLDER_WITH_SPECIAL_CHARS, NORMAL_FILE_NAME, NORMAL_TARGET_TMP);
 	}
 	
 	@Test
-	public void testRSyncLogRetrievalWithSpaceInFileToSynchronize() throws IOException {
+	public void testRSyncLogRetrievalWithSpaceInFileToSynchronize() throws Exception {
 		testRsyncLogRetrieval(NORMAL_FOLDER_NAME, FILE_NAME_SPECIAL_CHARS, NORMAL_TARGET_TMP);
 	}
 	
 	@Test
-	public void testRSyncLogRetrievalWithSpaceInTargetDirectory() throws IOException {
+	public void testRSyncLogRetrievalWithSpaceInTargetDirectory() throws Exception {
 		testRsyncLogRetrieval(NORMAL_FOLDER_NAME, NORMAL_FILE_NAME, TARGET_FOLDER_WITH_SPECIAL_CHARS);
 	}
 	
 	@Test
-	public void testRSyncLogRetrievalWithSpaceEverywhere() throws IOException {
+	public void testRSyncLogRetrievalWithSpaceEverywhere() throws Exception {
 		testRsyncLogRetrieval(SOURCE_FOLDER_WITH_SPECIAL_CHARS, FILE_NAME_SPECIAL_CHARS, TARGET_FOLDER_WITH_SPECIAL_CHARS);
 	}
 
-	protected void testRsyncLogRetrieval(String folderToSynchronizeName, String fileNameToSynchronize, String targetFolderPath) throws IOException {
+	protected void testRsyncLogRetrieval(String folderToSynchronizeName, String fileNameToSynchronize, String targetFolderPath) throws IOException, InterruptedException {
+		podFolderToClean  = targetFolderPath;
+		execOnPod(new String[] {"mkdir", "-p", targetFolderPath});
 		File localTempDir = tmpFolder.newFolder(folderToSynchronizeName);
-		// create a dummy file to be sure there will be something to rsync
-		final String fileName = File.createTempFile(fileNameToSynchronize, ".txt", localTempDir).getName();
+		// Create a dummy file locally to be sure there will be something to rsync from Local to Remote
+		File tmpFile = File.createTempFile(fileNameToSynchronize, ".txt", localTempDir);
+		final String fileName = tmpFile.getName();
+		LocalPeer localPeer = new LocalPeer(localTempDir.getAbsolutePath()+File.separator);
+		PodPeer podPeer = new PodPeer(targetFolderPath, pod);
 		
-		// run the rsync and collect the logs
-		 List<String> logs = pod.accept(new CapabilityVisitor<IRSyncable, List<String>>() {
+		// Check Local to Remote
+		rsyncAndCheck(fileName, localPeer, podPeer);
+		tmpFile.delete();
+		
+		// Create a dummy file locally to be sure there will be something to rsync from Remote to Local
+		execOnPod(new String[] {"touch", targetFolderPath +"/fileToSynchronizeBackFromPodToLocal.txt"});
+		
+		// Check Remote to Local
+		rsyncAndCheck("fileToSynchronizeBackFromPodToLocal", podPeer, localPeer);
+		assertThat(new File(localTempDir, "fileToSynchronizeBackFromPodToLocal.txt").exists()).isTrue();
+	}
+
+	protected void execOnPod(String[] commands) throws InterruptedException {
+		PodExecIntegrationTest.TestExecListener execListener = new PodExecIntegrationTest.TestExecListener();
+		final String container = pod.getContainers().iterator().next().getName();
+		IPodExec.Options options = new IPodExec.Options();
+		options.container( container );
+		
+		pod.accept(new CapabilityVisitor<IPodExec, IStoppable>() {
+
+			@Override
+			public IStoppable visit(IPodExec capability) {
+				return capability.start(execListener, options, commands);
+			}
+
+		}, null);
+		execListener.testDone.await( 10, TimeUnit.SECONDS );
+		assertTrue( execListener.openCalled.get() );
+		assertTrue( execListener.closeCalled.get() );
+		assertTrue( !execListener.failureCalled.get() );
+		assertTrue( !execListener.execErrCalled.get() );
+	}
+
+	protected void rsyncAndCheck(final String fileName, Peer source, Peer destination) {
+		List<String> logs = pod.accept(new CapabilityVisitor<IRSyncable, List<String>>() {
 
 			@Override
 			public List<String> visit(IRSyncable cap) {
 				try {
 					final BufferedReader reader = new BufferedReader(new InputStreamReader(
-							cap.sync(new LocalPeer(localTempDir.getAbsolutePath()), new PodPeer(targetFolderPath, pod), OpenShiftBinaryOption.SKIP_TLS_VERIFY)));
+							cap.sync(source, destination, OpenShiftBinaryOption.SKIP_TLS_VERIFY)));
 					List<String> logs = IOUtils.readLines(reader);
 					// wait until end of 'rsync'
 					cap.await();
@@ -129,8 +182,7 @@ public class OpenshiftBinaryRSyncRetrievalIntegrationTest {
 			LOG.debug("**** RSync Logs ****");
 			logs.forEach(l->LOG.debug(l));
 		}
-		// then
-		// verify that the logs contain a message about the dummy file
+		// then verify that the logs contain a message about the dummy file
 		assertThat(logs).isNotEmpty();
 		assertThat(logs.stream().anyMatch(line -> line.contains(fileName))).isTrue();
 	}


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>

Several points:
- I use a regex to parse a String to a List<String>, I think that it would be proper that buildArgs methods will return a List<String> directly (but requires to break at least internal API)
- the addition of double-quotes is not at the same place for Local and Pod Peers, I don't find it very nice but  not sure what is the best way:
-- introduce a new method getCommandLineLocation which will have the double-quote ta the right place?
-- always return location/parameter of Peer with the double-quotes? Is it used somewhere else?