### PR TITLE
[318] Multiple excludes for binary rsync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<!-- Artifact Information -->
 	<groupId>com.openshift</groupId>
 	<artifactId>openshift-restclient-java</artifactId>
-	<version>5.9.6.Final</version>
+	<version>6.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>OpenShift Java REST Client</name>
 	<url>http://openshift.redhat.com</url>

--- a/src/main/java/com/openshift/restclient/capability/IBinaryCapability.java
+++ b/src/main/java/com/openshift/restclient/capability/IBinaryCapability.java
@@ -12,21 +12,24 @@ package com.openshift.restclient.capability;
  * @author Andre Dietisheim
  */
 public interface IBinaryCapability extends ICapability {
-	
+
+	static final OpenShiftBinaryOption SKIP_TLS_VERIFY = new SkipTlsVerify();
+
 	/**
-	 * Optional arguments to pass when running the {@code oc} command.
+	 * Skips the SSL/TLS Verification when using a binary capability
 	 */
-	public enum OpenShiftBinaryOption {
-		/** option to skip verifying the certificates during TLS connection establishment. */
-		SKIP_TLS_VERIFY,
-		/** option to exclude the {@code .git} folder in the list of files/folders to synchronize. */
-		EXCLUDE_GIT_FOLDER,
-		/** option to not transfer file permissions. */
-		NO_PERMS,
-		/** option to delete delete extraneous files from destination directories**/
-		DELETE
+	static class SkipTlsVerify implements OpenShiftBinaryOption {
+
+		@Override
+		public void append(StringBuilder commandLine) {
+			commandLine.append(" --insecure-skip-tls-verify=true");
+		}
 	}
 	
+	static interface OpenShiftBinaryOption {
+		void append(StringBuilder builder);
+	}
+
 	static final String OPENSHIFT_BINARY_LOCATION = "openshift.restclient.oc.location";
 
 }

--- a/src/main/java/com/openshift/restclient/capability/resources/IPodLogRetrieval.java
+++ b/src/main/java/com/openshift/restclient/capability/resources/IPodLogRetrieval.java
@@ -12,8 +12,8 @@ package com.openshift.restclient.capability.resources;
 
 import java.io.InputStream;
 
-import com.openshift.restclient.capability.ICapability;
 import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
+import com.openshift.restclient.capability.ICapability;
 
 /**
  * 

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryPodLogRetrievalTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryPodLogRetrievalTest.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.capability.resources;
+
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.OC_LOCATION;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.POD_NAME;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.POD_NAMESPACE;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.SERVER_URL;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.TOKEN;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.mockClient;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.mockPod;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.net.MalformedURLException;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.openshift.internal.restclient.capability.resources.OpenShiftBinaryPodLogRetrieval.PodLogs;
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.capability.IBinaryCapability;
+import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
+import com.openshift.restclient.model.IPod;
+
+public class OpenShiftBinaryPodLogRetrievalTest {
+
+	private static final String CONTAINER_NAME = "smurfland";
+
+	private IClient client;
+	private IPod pod;
+
+	@Before
+	public void before() throws MalformedURLException {
+		this.client = mockClient();
+		this.pod = mockPod();
+	}
+
+	private OpenShiftBinaryPodLogRetrieval.PodLogs createPodLogs(boolean follow, IPod pod, IClient client, OpenShiftBinaryOption... options) {
+		OpenShiftBinaryPodLogRetrieval.PodLogs podLogs = spy(
+				new OpenShiftBinaryPodLogRetrieval(pod, client).new PodLogs(client, true, CONTAINER_NAME, options));
+		doReturn(OC_LOCATION).when(podLogs).getOpenShiftBinaryLocation();
+		doReturn(null).when(podLogs).startProcess(any(ProcessBuilder.class));
+		return podLogs;
+	}
+
+	@Test
+	public void shouldBuildCommandLineWithoutSkipTlsVerify() {
+		// given
+		ArgumentCaptor<ProcessBuilder> processBuilderArgument = ArgumentCaptor.forClass(ProcessBuilder.class);
+		PodLogs podLogs = createPodLogs(false, pod, client);
+		// when
+		podLogs.getLogs();
+		// then
+		verify(podLogs).startProcess(processBuilderArgument.capture());
+		ProcessBuilder builder = processBuilderArgument.getValue();
+		assertThat(builder.command()).isEqualTo(Arrays.asList(
+				OC_LOCATION,
+				PodLogs.LOGS_COMMAND,
+				"--token=" + TOKEN,
+				"--server=" + SERVER_URL.toString(),
+				POD_NAME,
+				"-n",
+				POD_NAMESPACE,
+				"-f",
+				"-c",
+				CONTAINER_NAME));
+	}
+
+	@Test
+	public void shouldBuildCommandLineWithSkipTlsVerify() {
+		// given
+		ArgumentCaptor<ProcessBuilder> processBuilderArgument = ArgumentCaptor.forClass(ProcessBuilder.class);
+		PodLogs podLogs = createPodLogs(false, pod, client, IBinaryCapability.SKIP_TLS_VERIFY);
+		// when
+		podLogs.getLogs();
+		// then
+		verify(podLogs).startProcess(processBuilderArgument.capture());
+		ProcessBuilder builder = processBuilderArgument.getValue();
+		assertThat(builder.command()).isEqualTo(Arrays.asList(
+				OC_LOCATION,
+				PodLogs.LOGS_COMMAND,
+				"--token=" + TOKEN,
+				"--server=" + SERVER_URL.toString(),
+				"--insecure-skip-tls-verify=true",
+				POD_NAME,
+				"-n",
+				POD_NAMESPACE,
+				"-f",
+				"-c",
+				CONTAINER_NAME));
+	}
+
+}

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryPortForwardingTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryPortForwardingTest.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.capability.resources;
+
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.OC_LOCATION;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.POD_NAME;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.POD_NAMESPACE;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.SERVER_URL;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.TOKEN;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.mockClient;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.mockPod;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.mockPortPair;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.net.MalformedURLException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.capability.IBinaryCapability.SkipTlsVerify;
+import com.openshift.restclient.capability.resources.IPortForwardable.PortPair;
+import com.openshift.restclient.model.IPod;
+
+public class OpenShiftBinaryPortForwardingTest {
+
+	private static final int LOCAL_PORT1 = 8080;
+	private static final int REMOTE_PORT1 = 80;
+
+	private static final int LOCAL_PORT2 = 8443;
+	private static final int REMOTE_PORT2 = 43;
+
+	private IPod pod;
+
+	private OpenShiftBinaryPortForwarding binaryPortForwarding;
+
+	@Before
+	public void before() throws MalformedURLException {
+		IClient client = mockClient();
+		this.pod = mockPod();
+		this.binaryPortForwarding = createBinaryPortForwarding(pod, client);
+	}
+
+	private OpenShiftBinaryPortForwarding createBinaryPortForwarding(IPod pod, IClient client) {
+		OpenShiftBinaryPortForwarding portForwarding = spy(new OpenShiftBinaryPortForwarding(pod, client));
+		doReturn(OC_LOCATION).when(portForwarding).getOpenShiftBinaryLocation();
+		doReturn(null).when(portForwarding).startProcess(any(ProcessBuilder.class));
+		return portForwarding;
+	}
+
+	@Test
+	public void shouldBuildCommandLineWithoutSkipSSL() {
+		// given
+		ArgumentCaptor<ProcessBuilder> processBuilderArgument = ArgumentCaptor.forClass(ProcessBuilder.class);
+		List<PortPair> ports = Arrays.asList(
+				mockPortPair(LOCAL_PORT2, REMOTE_PORT2));
+		// when
+		binaryPortForwarding.forwardPorts(ports);
+		// then
+		verify(binaryPortForwarding).startProcess(processBuilderArgument.capture());
+		ProcessBuilder builder = processBuilderArgument.getValue();
+		assertThat(builder.command()).isEqualTo(Arrays.asList(
+				OC_LOCATION,
+				OpenShiftBinaryPortForwarding.PORT_FORWARD_COMMAND,
+				"--token=" + TOKEN,
+				"--server=" + SERVER_URL.toString(),
+				"-n",
+				POD_NAMESPACE,
+				"-p",
+				POD_NAME,
+				LOCAL_PORT2 + ":" + REMOTE_PORT2));
+	}
+
+	@Test
+	public void shouldBuildCommandLineWith2PortsSkipSSL() {
+		// given
+		ArgumentCaptor<ProcessBuilder> processBuilderArgument = ArgumentCaptor.forClass(ProcessBuilder.class);
+		List<PortPair> ports = Arrays.asList(
+				mockPortPair(LOCAL_PORT1, REMOTE_PORT1), 
+				mockPortPair(LOCAL_PORT2, REMOTE_PORT2));
+		// when
+		binaryPortForwarding.forwardPorts(ports, new SkipTlsVerify());
+		// then
+		verify(binaryPortForwarding).startProcess(processBuilderArgument.capture());
+		ProcessBuilder builder = processBuilderArgument.getValue();
+		assertThat(builder.command()).isEqualTo(Arrays.asList(
+				OC_LOCATION,
+				OpenShiftBinaryPortForwarding.PORT_FORWARD_COMMAND,
+				"--token=" + TOKEN,
+				"--server=" + SERVER_URL.toString(),
+				"--insecure-skip-tls-verify=true",
+				"-n",
+				POD_NAMESPACE,
+				"-p",
+				POD_NAME,
+				LOCAL_PORT1 + ":" + REMOTE_PORT1,
+				LOCAL_PORT2 + ":" + REMOTE_PORT2));
+	}
+}

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryRSyncTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/OpenShiftBinaryRSyncTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.capability.resources;
+
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.OC_LOCATION;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.POD_NAME;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.POD_NAMESPACE;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.SERVER_URL;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.TOKEN;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.mockClient;
+import static com.openshift.internal.restclient.capability.resources.testutils.BinaryCapabilityTestMocks.mockPod;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.net.MalformedURLException;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.capability.IBinaryCapability.SkipTlsVerify;
+import com.openshift.restclient.capability.resources.IRSyncable.Exclude;
+import com.openshift.restclient.capability.resources.IRSyncable.GitFolderExclude;
+import com.openshift.restclient.capability.resources.IRSyncable.LocalPeer;
+import com.openshift.restclient.capability.resources.IRSyncable.NoPerms;
+import com.openshift.restclient.capability.resources.IRSyncable.Peer;
+import com.openshift.restclient.capability.resources.IRSyncable.PodPeer;
+import com.openshift.restclient.model.IPod;
+
+public class OpenShiftBinaryRSyncTest {
+
+	private static final String LOCAL_PATH = "/local/42";
+	private static final String POD_PATH = "/deployment/42";
+
+	private IPod pod;
+
+	private OpenShiftBinaryRSync binaryRsync;
+
+	@Before
+	public void before() throws MalformedURLException {
+		IClient client = mockClient();
+		this.pod = mockPod();
+		this.binaryRsync = createBinaryRSync(client);
+	}
+
+	private OpenShiftBinaryRSync createBinaryRSync(IClient client) {
+		OpenShiftBinaryRSync binaryRsync = spy(new OpenShiftBinaryRSync(client));
+		doReturn(OC_LOCATION).when(binaryRsync).getOpenShiftBinaryLocation();
+		doReturn(null).when(binaryRsync).startProcess(any(ProcessBuilder.class));
+		return binaryRsync;
+	}
+
+
+	@Test
+	public void shouldBuildCommandLineWithoutSkipSSL() {
+		// given
+		ArgumentCaptor<ProcessBuilder> processBuilderArgument = ArgumentCaptor.forClass(ProcessBuilder.class);
+		Peer localPeer = new LocalPeer(LOCAL_PATH);
+		PodPeer podPeer = new PodPeer(POD_PATH, pod);
+		// when
+		binaryRsync.sync(localPeer, podPeer);
+		// then
+		verify(binaryRsync).startProcess(processBuilderArgument.capture());
+		ProcessBuilder builder = processBuilderArgument.getValue();
+		assertThat(builder.command()).isEqualTo(Arrays.asList(
+				OC_LOCATION,
+				OpenShiftBinaryRSync.RSYNC_COMMAND,
+				"--token=" + TOKEN,
+				"--server=" + SERVER_URL.toString(),
+				"-n", 
+				POD_NAMESPACE,
+				LOCAL_PATH,
+				POD_NAME + ":" + POD_PATH));
+	}
+
+	@Test
+	public void shouldBuildCommandLineWithSkipSSLNoPermsGitExclude() {
+		// given
+		ArgumentCaptor<ProcessBuilder> processBuilderArgument = ArgumentCaptor.forClass(ProcessBuilder.class);
+		Peer localPeer = new LocalPeer(LOCAL_PATH);
+		PodPeer podPeer = new PodPeer(POD_PATH, pod);
+		// when
+		binaryRsync.sync(localPeer, podPeer, 
+				new SkipTlsVerify(), new NoPerms(), new GitFolderExclude());
+		// then
+		verify(binaryRsync).startProcess(processBuilderArgument.capture());
+		ProcessBuilder builder = processBuilderArgument.getValue();
+		assertThat(builder.command()).isEqualTo(Arrays.asList(
+				OC_LOCATION, 
+				OpenShiftBinaryRSync.RSYNC_COMMAND,
+				"--token=" + TOKEN,
+				"--server=" + SERVER_URL.toString(),
+				"-n",
+				POD_NAMESPACE,
+				"--insecure-skip-tls-verify=true",
+				"--no-perms=true",
+				"--exclude=.git",
+				LOCAL_PATH,
+				POD_NAME + ":" + POD_PATH));
+	}
+
+	@Test
+	public void shouldBuildCommandLineWithExcludeDotGitDotNpm() {
+		// given
+		ArgumentCaptor<ProcessBuilder> processBuilderArgument = ArgumentCaptor.forClass(ProcessBuilder.class);
+		Peer localPeer = new LocalPeer(LOCAL_PATH);
+		PodPeer podPeer = new PodPeer(POD_PATH, pod);
+		// when
+		binaryRsync.sync(localPeer, podPeer, 
+				new Exclude(".git", ".npm"));
+		// then
+		verify(binaryRsync).startProcess(processBuilderArgument.capture());
+		ProcessBuilder builder = processBuilderArgument.getValue();
+		assertThat(builder.command()).isEqualTo(Arrays.asList(
+				OC_LOCATION, 
+				OpenShiftBinaryRSync.RSYNC_COMMAND,
+				"--token=" + TOKEN,
+				"--server=" + SERVER_URL.toString(), 
+				"-n",
+				POD_NAMESPACE,
+				"--exclude=.git",
+				"--exclude=.npm",
+				LOCAL_PATH,
+				POD_NAME + ":" + POD_PATH));
+	}
+}

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryPodLogRetrievalIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryPodLogRetrievalIntegrationTest.java
@@ -25,7 +25,7 @@ import com.openshift.restclient.IClient;
 import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.capability.CapabilityVisitor;
 import com.openshift.restclient.capability.IBinaryCapability;
-import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
+import com.openshift.restclient.capability.IBinaryCapability.SkipTlsVerify;
 import com.openshift.restclient.capability.resources.IPodLogRetrieval;
 import com.openshift.restclient.model.IPod;
 import com.openshift.restclient.model.IResource;
@@ -54,7 +54,7 @@ public class OpenshiftBinaryPodLogRetrievalIntegrationTest {
 			public Exception visit(IPodLogRetrieval cap) {
 			    StringBuilder builder = new StringBuilder();
 				try {
-					BufferedInputStream os = new BufferedInputStream(cap.getLogs(false, OpenShiftBinaryOption.SKIP_TLS_VERIFY));
+					BufferedInputStream os = new BufferedInputStream(cap.getLogs(false, new SkipTlsVerify()));
 					int c;
 					while((c = os.read()) != -1) {
 					    builder.append((char)c);

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryPortForwardingIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryPortForwardingIntegrationTest.java
@@ -30,7 +30,7 @@ import com.openshift.internal.restclient.model.properties.ResourcePropertyKeys;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.capability.CapabilityVisitor;
 import com.openshift.restclient.capability.IBinaryCapability;
-import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
+import com.openshift.restclient.capability.IBinaryCapability.SkipTlsVerify;
 import com.openshift.restclient.capability.resources.IPortForwardable;
 import com.openshift.restclient.capability.resources.IPortForwardable.PortPair;
 import com.openshift.restclient.model.IProject;
@@ -76,7 +76,7 @@ public class OpenshiftBinaryPortForwardingIntegrationTest implements ResourcePro
 
 			@Override
 			public Object visit(IPortForwardable capability) {
-				capability.forwardPorts(Arrays.asList(new PortPair(8181, port)), OpenShiftBinaryOption.SKIP_TLS_VERIFY);
+				capability.forwardPorts(Arrays.asList(new PortPair(8181, port)), new SkipTlsVerify());
 				try {
 					Thread.sleep(5 * IntegrationTestHelper.MILLISECONDS_PER_SECOND);
 					curl();

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
@@ -10,6 +10,10 @@ package com.openshift.internal.restclient.capability.resources;
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -18,11 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.Assertions.*;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -40,8 +39,8 @@ import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.api.capabilities.IPodExec;
 import com.openshift.restclient.capability.CapabilityVisitor;
 import com.openshift.restclient.capability.IBinaryCapability;
+import com.openshift.restclient.capability.IBinaryCapability.SkipTlsVerify;
 import com.openshift.restclient.capability.IStoppable;
-import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
 import com.openshift.restclient.capability.resources.IRSyncable;
 import com.openshift.restclient.capability.resources.IRSyncable.LocalPeer;
 import com.openshift.restclient.capability.resources.IRSyncable.Peer;
@@ -166,7 +165,7 @@ public class OpenshiftBinaryRSyncRetrievalIntegrationTest {
 			public List<String> visit(IRSyncable cap) {
 				try {
 					final BufferedReader reader = new BufferedReader(new InputStreamReader(
-							cap.sync(source, destination, OpenShiftBinaryOption.SKIP_TLS_VERIFY)));
+							cap.sync(source, destination, new SkipTlsVerify())));
 					List<String> logs = IOUtils.readLines(reader);
 					// wait until end of 'rsync'
 					cap.await();

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/testutils/BinaryCapabilityTestMocks.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/testutils/BinaryCapabilityTestMocks.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.openshift.internal.restclient.capability.resources.testutils;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.authorization.IAuthorizationContext;
+import com.openshift.restclient.capability.resources.IPortForwardable.PortPair;
+import com.openshift.restclient.model.IPod;
+
+public class BinaryCapabilityTestMocks {
+
+	public static final String SERVER_URL = "https://localhost:8443";
+	public static final String TOKEN = "phWDXIqSspYBZARPQIzqaevHGDIxduQGbhcZuwj48EI";
+
+	public static final String OC_LOCATION = "/path/to/oc";
+
+	public static final String POD_NAME = "papa-smurf";
+	public static final String POD_NAMESPACE = "the-smurfs";
+
+	public static IClient mockClient() throws MalformedURLException {
+		IClient client = mock(IClient.class);
+		doReturn(new URL(SERVER_URL)).when(client).getBaseURL();
+		IAuthorizationContext context = mockAuthorizationContext();
+		doReturn(context).when(client).getAuthorizationContext();
+		return client;
+	}
+	
+	private static IAuthorizationContext mockAuthorizationContext() {
+		IAuthorizationContext context = mock(IAuthorizationContext.class);
+		doReturn(TOKEN).when(context).getToken();
+		return context;
+	}
+
+	public static IPod mockPod() {
+		IPod pod = mock(IPod.class);
+		doReturn(POD_NAME).when(pod).getName();
+		doReturn(POD_NAMESPACE).when(pod).getNamespace();
+		return pod;
+	}
+	
+	public static PortPair mockPortPair(int localPort, int remotePort) {
+		PortPair ports = mock(PortPair.class);
+		doReturn(localPort).when(ports).getLocalPort();
+		doReturn(remotePort).when(ports).getRemotePort();
+		return ports;
+	}
+}


### PR DESCRIPTION
provides a fix for #318 

This is breaking the public API, thus it's suggested at 6.0.0-SNAPSHOT