### PR TITLE
Support base-10 units for PV sizes

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/model/volume/PersistentVolume.java
+++ b/src/main/java/com/openshift/internal/restclient/model/volume/PersistentVolume.java
@@ -18,6 +18,8 @@ import java.util.regex.Pattern;
 
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.openshift.internal.restclient.model.KubernetesResource;
 import com.openshift.internal.restclient.model.volume.property.HostPathVolumeProperties;
@@ -32,6 +34,8 @@ import com.openshift.restclient.model.volume.property.IPersistentVolumePropertie
 import com.openshift.restclient.utils.MemoryUnit;
 
 public class PersistentVolume extends KubernetesResource implements IPersistentVolume {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PersistentVolume.class);
 
     private static final String PV_ACCESS_MODES = "spec.accessModes";
     private static final String PV_CAPACITY = "spec.capacity.storage";
@@ -243,6 +247,7 @@ public class PersistentVolume extends KubernetesResource implements IPersistentV
         if ( bytes % designatedUnit.getFactor() == 0L ) {
             return bytes / designatedUnit.getFactor();
         }
+        LOGGER.warn("Could not convert capacity: {} to unit {}", capacity, designatedUnit);
         return 0L;
     }
 

--- a/src/main/java/com/openshift/restclient/model/volume/IPersistentVolume.java
+++ b/src/main/java/com/openshift/restclient/model/volume/IPersistentVolume.java
@@ -22,7 +22,8 @@ public interface IPersistentVolume extends IResource {
 
     /**
      * @param unit
-     *            the designated unit. One of "Ki", "Mi", "Gi", "Ti", "Pi", "Ei".
+     *            the designated unit. One of "B", "K", "Ki", "M", "Mi", "G", "Gi",
+     *            "T", "Ti", "P", "Pi", "E", "Ei".
      * @return 0, if conversion not possible. Otherwise the capacity in given units.
      * @see {@link PersistentVolume#convert(String, MemoryUnit)}
      * @throws IllegalArgumentException
@@ -32,8 +33,8 @@ public interface IPersistentVolume extends IResource {
 
     /**
      * @param unit
-     *            the designated unit. One of {@link MemoryUnit}'s Ki, Mi, Gi, Ti,
-     *            Pi, Ei.
+     *            the designated unit. One of {@link MemoryUnit}'s B, K, Ki, M, Mi,
+     *            G, Gi, T, Ti, P, Pi, E, Ei.
      * @return 0, if conversion not possible. Otherwise the capacity in given units.
      * @see {@link PersistentVolume#convert(String, MemoryUnit)}
      * @throws IllegalArgumentException

--- a/src/main/java/com/openshift/restclient/utils/MemoryUnit.java
+++ b/src/main/java/com/openshift/restclient/utils/MemoryUnit.java
@@ -12,7 +12,21 @@
 package com.openshift.restclient.utils;
 
 public enum MemoryUnit {
+    B(1l), K(1000l), Ki(1024l), M(1000l*1000l), Mi(1024l*1024l), 
+        G(1000l*1000l*1000l), Gi(1024l*1024l*1024l), 
+        T(1000l*1000l*1000l*1000l), Ti(1024l*1024l*1024l*1024l),
+        P(1000l*1000l*1000l*1000l*1000l), 
+        Pi(1024l*1024l*1024l*1024l*1024l), 
+        E(1000l*1000l*1000l*1000l*1000l*1000l),
+        Ei(1024l*1024l*1024l*1024l*1024l*1024l);
 
-    Ki, Mi, Gi, Ti, Pi, Ei;
+    private final long factor;
 
+    private MemoryUnit(long factor) {
+        this.factor = factor;
+    }
+
+    public long getFactor() {
+        return factor;
+    }
 }


### PR DESCRIPTION
I've tried to add support for base-10 units without introducing incompatibilities. Note, however, that mixing base-10 and base-2 units in a cluster basically makes the PersistentVolume.getCapacity(String) and PersistentVolume.getCapacity(MemoryUnit) methods useless, because they return 0 if conversion between the two bases would be required (I'm not saying this makes sense, I just tried to change the behavior as little as possible). IMHO these methods should be deprecated and eventually removed. getCapacity() is fine because it returns bytes, which always works.

What do you think?