### PR TITLE
[#345] use /healthz for server health checks

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/DefaultClient.java
+++ b/src/main/java/com/openshift/internal/restclient/DefaultClient.java
@@ -64,6 +64,8 @@ public class DefaultClient implements IClient, IHttpConstants {
     public static final String SYSTEM_PROP_K8E_API_VERSION = "osjc.k8e.apiversion";
     public static final String SYSTEM_PROP_OPENSHIFT_API_VERSION = "osjc.openshift.apiversion";
 
+    private static final String URL_HEALTH_CHECK = "healthz";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultClient.class);
     private URL baseUrl;
     private OkHttpClient client;
@@ -288,7 +290,7 @@ public class DefaultClient implements IClient, IHttpConstants {
     @Override
     public String getServerReadyStatus() {
         try {
-            Request request = new Request.Builder().url(new URL(this.baseUrl, "healthz/ready"))
+            Request request = new Request.Builder().url(new URL(this.baseUrl, URL_HEALTH_CHECK))
                     .header(PROPERTY_ACCEPT, "*/*").build();
             try (Response response = client.newCall(request).execute()) {
                 return response.body().string();


### PR DESCRIPTION
/healthz/ready was deprecated in 3.10, gives 404. /healthz existed since
at least OS 1.5.