### PR TITLE
using java.util.Base64 instead of javax.xml.bind.DatatypeConverter

### DIFF
--- a/src/main/java/com/openshift/restclient/utils/Base64Coder.java
+++ b/src/main/java/com/openshift/restclient/utils/Base64Coder.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2013 Red Hat, Inc. 
+4 * Copyright (c) 2013-2018 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -11,9 +11,10 @@
 
 package com.openshift.restclient.utils;
 
-import javax.xml.bind.DatatypeConverter;
+import java.nio.charset.Charset;
+import java.util.Base64;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.ArrayUtils;
 
 /**
  * A utility class that offers methods to encode and decode strings from and to
@@ -28,19 +29,36 @@ public class Base64Coder {
     }
 
     /**
-     * Encodes the given byte array to a base64 encoded String
+     * Encodes the given byte array to a base64 encoded String. returns {@code null}
+     * if the given byte array is null, empty string if the given byte array is
+     * empty.
      * 
-     * @param unencoded
-     *            the array of unencoded bytes that shall get encoded
-     * @return the encoded string
+     * @param unencoded the array of unencoded bytes that shall get encoded
+     * @return the encoded string created using the platform standard charset
+     * 
+     * @see  Charset#defaultCharset
      */
     public static String encode(byte[] unencoded) {
+        return encode(unencoded, Charset.defaultCharset());
+    }
+
+    /**
+     * Encodes the given byte array to a base64 encoded String. returns {@code null}
+     * if the given byte array is null, empty string if the given byte array is
+     * empty.
+     * 
+     * @param unencoded the array of unencoded bytes that shall get encoded
+     * @return the encoded string created using the platform standard charset
+     * 
+     * @see  Charset#defaultCharset
+     */
+    public static String encode(byte[] unencoded, Charset charset) {
         if (unencoded == null) {
             return null;
         } else if (unencoded.length == 0) {
-            return new String();
+            return "";
         }
-        return DatatypeConverter.printBase64Binary(unencoded);
+        return new String(Base64.getEncoder().encode(unencoded), charset);
     }
 
     /**
@@ -49,21 +67,28 @@ public class Base64Coder {
      * 
      */
     public static String encode(String unencoded) {
-        if (StringUtils.isEmpty(unencoded)) {
-            return unencoded;
+        if (unencoded == null) {
+            return null;
         }
-        return encode(unencoded.getBytes());
+        return encode(unencoded.getBytes(), Charset.defaultCharset());
     }
 
-    public static String decode(byte[] encoded) {
-        if (encoded == null || encoded.length == 0) {
-            return new String();
+    public static String encode(String unencoded, Charset charset) {
+        if (unencoded == null) {
+            return null;
         }
-        return decode(new String(encoded));
+        return encode(unencoded.getBytes(), charset);
+    }
+
+    public static String decode(byte[] encoded, Charset charset) {
+        if (ArrayUtils.isEmpty(encoded)) {
+            return "";
+        }
+        return new String(Base64.getDecoder().decode(encoded), charset);
     }
 
     /**
-     * Decodes the given base64 encoded string. Returns <code>null</code> if the
+     * Decodes the given base64 encoded string assuming the default charset. Returns <code>null</code> if the
      * given string is <code>null</code>.
      * 
      * @param encoded
@@ -71,22 +96,21 @@ public class Base64Coder {
      * @return the decoded string
      */
     public static String decode(String encoded) {
-        byte[] encodedBytes = decodeBinary(encoded);
-        return (encodedBytes == null) ? encoded : new String(DatatypeConverter.parseBase64Binary(encoded));
+        if (encoded == null) {
+            return null;
+        }
+        return decode(encoded.getBytes(Charset.defaultCharset()), Charset.defaultCharset());
     }
 
     /**
-     * Decodes the given base64 encoded string. Returns <code>null</code> if the
-     * given string is <code>null</code>.
+     * Decodes the given base64 encoded string using the default charset. Returns
+     * <code>null</code> if the given string is <code>null</code>.
      * 
-     * @param encoded
-     *            the base64 encoded string
+     * @param encoded the base64 encoded string
      * @return the decoded binary data
      */
     public static byte[] decodeBinary(String encoded) {
-        if (StringUtils.isEmpty(encoded)) {
-            return null;
-        }
-        return DatatypeConverter.parseBase64Binary(encoded);
+        Charset charset = Charset.defaultCharset();
+        return decode(encoded.getBytes(charset), charset).getBytes(charset);
     }
 }

--- a/src/test/java/com/openshift/internal/restclient/model/v1/SecretTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/SecretTest.java
@@ -52,7 +52,7 @@ public class SecretTest {
 
     @Test
     public void testGetData() {
-        assertTrue(StringUtils.isNotBlank(new String(secret.getData(".dockercfg"))));
+        assertEquals("value-1", new String(secret.getData(".dockercfg")));
     }
 
     @Test

--- a/src/test/resources/samples/openshift3/v1_secret.json
+++ b/src/test/resources/samples/openshift3/v1_secret.json
@@ -15,7 +15,7 @@
         }
     },
     "data": {
-        ".dockercfg": "value-1"
+        ".dockercfg": "dmFsdWUtMQ=="
     },
     "type": "kubernetes.io/dockercfg"
 }


### PR DESCRIPTION
...to allow us to run on jdk9+
Signed-off-by: Andre Dietisheim <adietish@redhat.com>