### PR TITLE
Use JDK11 instead of JDK9 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
+  - oraclejdk11
 
 script:
   mvn clean verify


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>