### PR TITLE
OSJC-285: fix CVE-2018-20200

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.11.0</version>
+            <version>3.14.2</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>


### PR DESCRIPTION
- Updated okhttp from 3.11.0 to 3.14.2

Signed-off-by: Jeff MAURY <jmaury@redhat.com>