### PR TITLE
OSJC-286: OCP4 support

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/ApiTypeMapper.java
+++ b/src/main/java/com/openshift/internal/restclient/ApiTypeMapper.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2016-2019 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -19,9 +19,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
 import org.jboss.dmr.ModelNode;
@@ -52,6 +52,7 @@ public class ApiTypeMapper implements IApiTypeMapper, ResourcePropertyKeys {
     private final String baseUrl;
     private final OkHttpClient client;
     private List<VersionedApiResource> resourceEndpoints;
+    private List<IVersionedType> types;
     private final Map<String, String> preferedVersion = new HashMap<>(2);
     private boolean initialized = false;
 
@@ -95,11 +96,14 @@ public class ApiTypeMapper implements IApiTypeMapper, ResourcePropertyKeys {
 
     private IVersionedApiResource endpointFor(String version, String kind) {
         String[] split = StringUtils.isBlank(version) ? new String[] {} : version.split(FWD_SLASH);
-        Optional<IVersionedApiResource> result = null;
+        Optional<? extends IVersionedApiResource> result = null;
         if (split.length <= 1) {
-            result = Stream.of(KUBE_API, OS_API)
-                    .map(api -> formatEndpointFor(api, (split.length == 0 ? preferedVersion.get(api) : split[0]), kind))
-                    .filter(e -> resourceEndpoints.contains(e)).findFirst();
+            result = resourceEndpoints.stream().filter(e -> {
+                return e.getName().equals(ResourceKind.pluralize(kind, true, true))
+                        && (split.length == 0 || e.getVersion().equals(split[split.length - 1]))
+                        && (split.length < 2 || e.getApiGroupName().equals(split[0]));
+
+            }).findFirst();
         } else {
             result = Optional.of(formatEndpointFor(API_GROUPS_API, version, kind));
         }
@@ -116,25 +120,48 @@ public class ApiTypeMapper implements IApiTypeMapper, ResourcePropertyKeys {
         return new VersionedApiResource(prefix, version, ResourceKind.pluralize(kind, true, true));
     }
 
+    @Override
+    public IVersionedType getType(String apiVersion, String kind) {
+        init();
+        IVersionedType type = typeFor(apiVersion, kind);
+        if (type == null) {
+            throw new UnsupportedEndpointException("No endpoint found for %s, version %s", kind, apiVersion);
+        }
+        return type;
+    }
+
+    private IVersionedType typeFor(String version, String kind) {
+        String[] split = StringUtils.isBlank(version) ? new String[] {} : version.split(FWD_SLASH);
+        Optional<? extends IVersionedType> result = null;
+        result = types.stream().filter(e -> {
+            return e.getKind().equals(kind) && (split.length == 0 || split[split.length - 1].equals(e.getVersion()))
+                    && (split.length < 2 || split[0].equals(e.getApiGroupName()));
+
+        }).findFirst();
+        return result.orElse(null);
+    }
+
     private synchronized void init() {
         if (!this.initialized) {
             List<VersionedApiResource> resourceEndpoints = new ArrayList<>();
+            List<IVersionedType> types = new ArrayList<>();
             Collection<ApiGroup> groups = getLegacyGroups();
             groups.addAll(getApiGroups());
             groups.forEach(g -> {
                 Collection<String> versions = g.getVersions();
                 versions.forEach(v -> {
                     Collection<ModelNode> resources = getResources(g, v);
-                    addEndpoints(resourceEndpoints, g.getPrefix(), g.getName(), v, resources);
+                    addEndpoints(resourceEndpoints, types, g.getPrefix(), g.getName(), v, resources);
                 });
             });
             this.resourceEndpoints = resourceEndpoints;
+            this.types = types;
             this.initialized = true;
         }
     }
 
-    private void addEndpoints(List<VersionedApiResource> endpoints, final String prefix, final String apiGroupName,
-            final String version, final Collection<ModelNode> nodes) {
+    private void addEndpoints(List<VersionedApiResource> endpoints, List<IVersionedType> types, final String prefix,
+            final String apiGroupName, final String version, final Collection<ModelNode> nodes) {
         for (ModelNode node : nodes) {
             String name = node.get(NAME).asString();
             String capability = null;
@@ -143,15 +170,27 @@ public class ApiTypeMapper implements IApiTypeMapper, ResourcePropertyKeys {
                 capability = name.substring(first + 1);
                 name = name.substring(0, first);
             }
+            String kind = node.get(KIND).asString();
+            String typeApiGroupName = node.has(GROUP) ? node.get(GROUP).asString() : null;
+            String typeVersion = node.has(VERSION) ? node.get(VERSION).asString() : null;
             boolean namespaced = node.get("namespaced").asBoolean();
-            VersionedApiResource resource = new VersionedApiResource(prefix, apiGroupName, version, name,
-                    node.get(KIND).asString(), namespaced);
-            if (!endpoints.contains(resource)) {
-                endpoints.add(resource);
+            VersionedApiResource resource = new VersionedApiResource(prefix, apiGroupName, version, name, kind,
+                    namespaced);
+            VersionedType type = new VersionedType(prefix, typeApiGroupName != null ? typeApiGroupName : apiGroupName,
+                    typeVersion != null ? typeVersion : version, kind);
+            if (capability == null && node.has(VERBS) && !node.get(VERBS).asList().isEmpty()) {
+                if (!endpoints.contains(resource)) {
+                    endpoints.add(resource);
+                }
+            }
+            if (!types.contains(type)) {
+                types.add(type);
             }
             if (capability != null) {
                 int index = endpoints.indexOf(resource);
-                endpoints.get(index).addCapability(capability);
+                if (index != (-1)) {
+                    endpoints.get(index).addCapability(capability);
+                }
             }
         }
     }
@@ -163,20 +202,29 @@ public class ApiTypeMapper implements IApiTypeMapper, ResourcePropertyKeys {
     }
 
     private Collection<ModelNode> getResources(IApiGroup group, String version) {
-        String json = readEndpoint(group.pathFor(version));
-        if (StringUtils.isBlank(json)) {
+        try {
+            String json = readEndpoint(group.pathFor(version));
+            if (StringUtils.isBlank(json)) {
+                return new ArrayList<>();
+            }
+            ModelNode node = ModelNode.fromJSONString(json);
+            return node.get("resources").asList();
+        } catch (Exception e) {
+            LOGGER.error("Can't load api group {}", group.pathFor(version));
             return new ArrayList<>();
         }
-        ModelNode node = ModelNode.fromJSONString(json);
-        return node.get("resources").asList();
     }
 
     private Collection<ApiGroup> getLegacyGroups() {
         Collection<ApiGroup> groups = new ArrayList<>();
         for (String e : Arrays.asList(KUBE_API, OS_API)) {
-            String json = readEndpoint(e);
-            ModelNode n = ModelNode.fromJSONString(json);
-            groups.add(new LegacyApiGroup(e, n));
+            try {
+                String json = readEndpoint(e);
+                ModelNode n = ModelNode.fromJSONString(json);
+                groups.add(new LegacyApiGroup(e, n));
+            } catch (Exception ex) {
+                LOGGER.error("Can't access legacy endpoint {}", e);
+            }
         }
         return groups;
     }
@@ -400,5 +448,60 @@ public class ApiTypeMapper implements IApiTypeMapper, ResourcePropertyKeys {
             return true;
         }
 
+    }
+
+    static class VersionedType implements IVersionedType {
+        private String prefix;
+        private String apiGroupName;
+        private String version;
+        private String kind;
+
+        VersionedType(String prefix, String apiGroupName, String version, String kind) {
+            this.prefix = prefix;
+            this.apiGroupName = apiGroupName;
+            this.version = version;
+            this.kind = kind;
+        }
+
+        @Override
+        public String getPrefix() {
+            return prefix;
+        }
+
+        @Override
+        public String getApiGroupName() {
+            return apiGroupName;
+        }
+
+        @Override
+        public String getVersion() {
+            return version;
+        }
+
+        @Override
+        public String getKind() {
+            return kind;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(apiGroupName, kind, version);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (!(obj instanceof VersionedType)) {
+                return false;
+            }
+            VersionedType other = (VersionedType) obj;
+            return Objects.equals(apiGroupName, other.apiGroupName) && Objects.equals(kind, other.kind)
+                    && Objects.equals(version, other.version);
+        }
     }
 }

--- a/src/main/java/com/openshift/internal/restclient/DefaultClient.java
+++ b/src/main/java/com/openshift/internal/restclient/DefaultClient.java
@@ -658,6 +658,9 @@ public class DefaultClient implements IClient, IHttpConstants {
         if (ICapability.class.isAssignableFrom(klass) && this.supports((Class<? extends ICapability>) klass)) {
             return (T) getCapability((Class<? extends ICapability>) klass);
         }
+        if (IResourceFactory.class.equals(klass)) {
+            return (T) this.factory;
+        }
         return null;
     }
 

--- a/src/main/java/com/openshift/internal/restclient/ResourceFactory.java
+++ b/src/main/java/com/openshift/internal/restclient/ResourceFactory.java
@@ -169,7 +169,7 @@ public class ResourceFactory implements IResourceFactory {
         String[] elements = ResourceKind.parse(kind);
         IVersionedType type = client.adapt(IApiTypeMapper.class).getType(elements[0], elements[1]);
         if (type != null) {
-            KubernetesResource resource = (KubernetesResource) create(type.getApiGroupNameAndVersion(), elements[1]);
+            KubernetesResource resource = create(type.getApiGroupNameAndVersion(), elements[1]);
             resource.setName(name);
             resource.setNamespace(namespace);
             if (StringUtils.isNotEmpty(namespace)) {

--- a/src/main/java/com/openshift/internal/restclient/ResourceFactory.java
+++ b/src/main/java/com/openshift/internal/restclient/ResourceFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
@@ -24,42 +24,10 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jboss.dmr.ModelNode;
 
-import com.openshift.internal.restclient.model.Build;
-import com.openshift.internal.restclient.model.BuildConfig;
-import com.openshift.internal.restclient.model.ConfigMap;
-import com.openshift.internal.restclient.model.DeploymentConfig;
-import com.openshift.internal.restclient.model.ImageStream;
-import com.openshift.internal.restclient.model.KubernetesEvent;
 import com.openshift.internal.restclient.model.KubernetesResource;
-import com.openshift.internal.restclient.model.LimitRange;
-import com.openshift.internal.restclient.model.Namespace;
-import com.openshift.internal.restclient.model.Pod;
-import com.openshift.internal.restclient.model.Project;
-import com.openshift.internal.restclient.model.ReplicationController;
-import com.openshift.internal.restclient.model.ResourceQuota;
-import com.openshift.internal.restclient.model.Route;
-import com.openshift.internal.restclient.model.Secret;
-import com.openshift.internal.restclient.model.Service;
-import com.openshift.internal.restclient.model.ServiceAccount;
-import com.openshift.internal.restclient.model.Status;
-import com.openshift.internal.restclient.model.authorization.OpenshiftPolicy;
-import com.openshift.internal.restclient.model.authorization.OpenshiftRole;
-import com.openshift.internal.restclient.model.authorization.PolicyBinding;
-import com.openshift.internal.restclient.model.authorization.RoleBinding;
-import com.openshift.internal.restclient.model.build.BuildRequest;
-import com.openshift.internal.restclient.model.image.ImageStreamImport;
-import com.openshift.internal.restclient.model.oauth.OAuthAccessToken;
-import com.openshift.internal.restclient.model.oauth.OAuthAuthorizeToken;
-import com.openshift.internal.restclient.model.oauth.OAuthClient;
-import com.openshift.internal.restclient.model.oauth.OAuthClientAuthorization;
-import com.openshift.internal.restclient.model.project.OpenshiftProjectRequest;
 import com.openshift.internal.restclient.model.properties.ResourcePropertiesRegistry;
-import com.openshift.internal.restclient.model.template.Template;
-import com.openshift.internal.restclient.model.user.OpenShiftUser;
-import com.openshift.internal.restclient.model.volume.PersistentVolume;
-import com.openshift.internal.restclient.model.volume.PersistentVolumeClaim;
 import com.openshift.restclient.IApiTypeMapper;
-import com.openshift.restclient.IApiTypeMapper.IVersionedApiResource;
+import com.openshift.restclient.IApiTypeMapper.IVersionedType;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.IResourceFactory;
 import com.openshift.restclient.ResourceFactoryException;
@@ -77,49 +45,6 @@ public class ResourceFactory implements IResourceFactory {
     private static final String APIVERSION = "apiVersion";
     private static final Map<String, Class<? extends IResource>> IMPL_MAP = new HashMap<>();
 
-    static {
-        // OpenShift kinds
-        IMPL_MAP.put(ResourceKind.BUILD, Build.class);
-        IMPL_MAP.put(ResourceKind.BUILD_CONFIG, BuildConfig.class);
-        IMPL_MAP.put(ResourceKind.BUILD_REQUEST, BuildRequest.class);
-        IMPL_MAP.put(ResourceKind.DEPLOYMENT_CONFIG, DeploymentConfig.class);
-        IMPL_MAP.put(ResourceKind.IMAGE_STREAM, ImageStream.class);
-        IMPL_MAP.put(ResourceKind.IMAGE_STREAM_IMPORT, ImageStreamImport.class);
-        IMPL_MAP.put(ResourceKind.LIST, com.openshift.internal.restclient.model.List.class);
-        IMPL_MAP.put(ResourceKind.NAMESPACE, Namespace.class);
-        IMPL_MAP.put(ResourceKind.OAUTH_ACCESS_TOKEN, OAuthAccessToken.class);
-        IMPL_MAP.put(ResourceKind.OAUTH_AUTHORIZE_TOKEN, OAuthAuthorizeToken.class);
-        IMPL_MAP.put(ResourceKind.OAUTH_CLIENT, OAuthClient.class);
-        IMPL_MAP.put(ResourceKind.OAUTH_CLIENT_AUTHORIZATION, OAuthClientAuthorization.class);
-        IMPL_MAP.put(ResourceKind.PROJECT, Project.class);
-        IMPL_MAP.put(ResourceKind.PROJECT_REQUEST, OpenshiftProjectRequest.class);
-        IMPL_MAP.put(ResourceKind.POLICY, OpenshiftPolicy.class);
-        IMPL_MAP.put(ResourceKind.POLICY_BINDING, PolicyBinding.class);
-        IMPL_MAP.put(ResourceKind.ROLE, OpenshiftRole.class);
-        IMPL_MAP.put(ResourceKind.ROLE_BINDING, RoleBinding.class);
-        IMPL_MAP.put(ResourceKind.ROUTE, Route.class);
-        IMPL_MAP.put(ResourceKind.TEMPLATE, Template.class);
-        IMPL_MAP.put(ResourceKind.USER, OpenShiftUser.class);
-
-        // Kubernetes Kinds
-        IMPL_MAP.put(ResourceKind.EVENT, KubernetesEvent.class);
-        IMPL_MAP.put(ResourceKind.LIMIT_RANGE, LimitRange.class);
-        IMPL_MAP.put(ResourceKind.POD, Pod.class);
-        IMPL_MAP.put(ResourceKind.PVC, PersistentVolumeClaim.class);
-        IMPL_MAP.put(ResourceKind.PERSISTENT_VOLUME, PersistentVolume.class);
-        IMPL_MAP.put(ResourceKind.RESOURCE_QUOTA, ResourceQuota.class);
-        IMPL_MAP.put(ResourceKind.REPLICATION_CONTROLLER, ReplicationController.class);
-        IMPL_MAP.put(ResourceKind.STATUS, Status.class);
-        IMPL_MAP.put(ResourceKind.SERVICE, Service.class);
-        IMPL_MAP.put(ResourceKind.SECRET, Secret.class);
-        IMPL_MAP.put(ResourceKind.SERVICE_ACCOUNT, ServiceAccount.class);
-        IMPL_MAP.put(ResourceKind.CONFIG_MAP, ConfigMap.class);
-
-        // fallback
-        IMPL_MAP.put(ResourceKind.UNRECOGNIZED, KubernetesResource.class);
-
-    }
-    
     private IClient client;
 
     public ResourceFactory(IClient client) {
@@ -226,28 +151,13 @@ public class ResourceFactory implements IResourceFactory {
     
     @SuppressWarnings("unchecked")
     private Class<? extends IResource> getResourceClass(String version, String kind) {
-        if (IMPL_MAP.containsKey(kind)) {
-            return IMPL_MAP.get(kind);
-        }
         IApiTypeMapper mapper = this.client.adapt(IApiTypeMapper.class);
         if (mapper != null) {
-            IVersionedApiResource endpoint = mapper.getEndpointFor(version, kind);
-            String extension = "";
-            switch (endpoint.getPrefix()) {
-            case IApiTypeMapper.KUBE_API:
-            case IApiTypeMapper.OS_API:
-                break;
-            default:
-                String extPlusVersion = endpoint.getApiGroupName();
-                extension = StringUtils.split(extPlusVersion, IApiTypeMapper.FWD_SLASH)[0];
-            }
             try {
-                String classname = String.format("com.openshift.internal.restclient.%s%s.models.%s",
-                        endpoint.getPrefix(), extension, endpoint.getKind());
-                return (Class<? extends IResource>) Class.forName(classname);
-            } catch (ClassNotFoundException e) {
-                // class doesnt exist in the exp location.
-                // fallback to an explicit registration
+                IVersionedType type = mapper.getType(version, kind);
+                return (Class<? extends IResource>) TypeRegistry.getInstance().getRegisteredType(type.getApiGroupNameAndVersion() + IApiTypeMapper.DOT + type.getKind());
+            } catch (Exception e) {
+                return (Class<? extends IResource>) TypeRegistry.getInstance().getRegisteredType(version + IApiTypeMapper.DOT + kind);
             }
         }
         return null;
@@ -256,15 +166,19 @@ public class ResourceFactory implements IResourceFactory {
     @SuppressWarnings("unchecked")
     @Override
     public <T extends IResource> T stub(String kind, String name, String namespace) {
-        // TODO get k8e or os
-        String version = client.getOpenShiftAPIVersion();
-        KubernetesResource resource = (KubernetesResource) create(version, kind);
-        resource.setName(name);
-        resource.setNamespace(namespace);
-        if (StringUtils.isNotEmpty(namespace)) {
+        String[] elements = ResourceKind.parse(kind);
+        IVersionedType type = client.adapt(IApiTypeMapper.class).getType(elements[0], elements[1]);
+        if (type != null) {
+            KubernetesResource resource = (KubernetesResource) create(type.getApiGroupNameAndVersion(), elements[1]);
+            resource.setName(name);
             resource.setNamespace(namespace);
+            if (StringUtils.isNotEmpty(namespace)) {
+                resource.setNamespace(namespace);
+            }
+            return (T) resource;
+        } else {
+            throw new ResourceFactoryException(null, "Unable to create resource from kind %s", kind);
         }
-        return (T) resource;
     }
 
     @Override

--- a/src/main/java/com/openshift/internal/restclient/TypeRegistry.java
+++ b/src/main/java/com/openshift/internal/restclient/TypeRegistry.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors: Red Hat, Inc.
+ ******************************************************************************/
+
+package com.openshift.internal.restclient;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import org.jboss.dmr.ModelNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.api.models.ITypeMeta;
+import com.openshift.restclient.model.IResource;
+
+/**
+ * Registry for types implemented by custom classes
+ *
+ */
+public class TypeRegistry {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(TypeRegistry.class);
+    
+    private static final String RESOURCE_NAME = "k8stypes.properties";
+    
+    private static TypeRegistry instance;
+    
+    public static final TypeRegistry getInstance() {
+        if (instance == null) {
+            instance = new TypeRegistry();
+        }
+        return instance;
+    }
+    
+    private Map<String, Class<?>> registeredTypes = new HashMap<>();
+    
+    private TypeRegistry() {
+        load();
+    }
+    
+    private void load() {
+        try {
+            Enumeration<URL> urls = TypeRegistry.class.getClassLoader().getResources(RESOURCE_NAME);
+            while (urls.hasMoreElements()) {
+                URL url = urls.nextElement();
+                try (InputStream is = url.openStream()) {
+                    load(is);
+                } catch (IOException e) {
+                    LOGGER.error("Can't load resource from " + url, e);
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.error("Can't load resources from " + RESOURCE_NAME, e);
+        }
+    }
+    
+    private void load(InputStream stream) throws IOException {
+        Properties p = new Properties();
+        p.load(stream);
+        for (Entry<Object, Object> entry : p.entrySet()) {
+            try {
+                String className = (String) entry.getKey();
+                Class<?> clazz = Class.forName(className);
+                if (check(clazz)) {
+                    String types = (String) entry.getValue();
+                    for (String type : types.split(",")) {
+                        registeredTypes.put(type, clazz);
+                    }
+                }
+            } catch (ClassNotFoundException e) {
+                LOGGER.warn("Can't load class", e);
+            }
+        }
+    }
+    
+    private boolean check(Class<?> clazz) {
+        boolean valid = false;
+        if (IResource.class.isAssignableFrom(clazz)) {
+            try {
+                clazz.getConstructor(ModelNode.class, IClient.class, Map.class);
+                valid = true;
+            } catch (NoSuchMethodException | SecurityException e) {
+                LOGGER.error(e.getLocalizedMessage(), e);
+            }
+        } else if (ITypeMeta.class.isAssignableFrom(clazz)) {
+            try {
+                clazz.getConstructor(ModelNode.class, Map.class);
+                valid = true;
+            } catch (NoSuchMethodException | SecurityException e) {
+                LOGGER.error(e.getLocalizedMessage(), e);
+            }
+        }
+        return valid;
+    }
+    
+    public Class<?> getRegisteredType(String kind) {
+        return registeredTypes.get(kind);
+    }
+}

--- a/src/main/java/com/openshift/internal/restclient/apis/TypeMetaFactory.java
+++ b/src/main/java/com/openshift/internal/restclient/apis/TypeMetaFactory.java
@@ -88,13 +88,16 @@ public class TypeMetaFactory implements ITypeFactory, ResourcePropertyKeys {
             Map<String, String[]> properyKeyMap = ResourcePropertiesRegistry.getInstance().get(version, kind);
             Class<? extends ITypeMeta> clazz = (Class<? extends ITypeMeta>) TypeRegistry.getInstance().getRegisteredType(version + IApiTypeMapper.DOT + kind);
                     
-            if (clazz != null) {
-                Constructor<? extends ITypeMeta> constructor = clazz.getConstructor(ModelNode.class,
-                        Map.class);
-                return constructor.newInstance(node, properyKeyMap);
+            try {
+                if (clazz != null) {
+                    Constructor<? extends ITypeMeta> constructor = clazz.getConstructor(ModelNode.class,
+                            Map.class);
+                    return constructor.newInstance(node, properyKeyMap);
+                }
+            } catch (Exception e) {
+                return new TypeMeta(node, properyKeyMap);
             }
             return new TypeMeta(node, properyKeyMap);
-
         } catch (UnsupportedVersionException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/com/openshift/internal/restclient/capability/CapabilityInitializer.java
+++ b/src/main/java/com/openshift/internal/restclient/capability/CapabilityInitializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html

--- a/src/main/java/com/openshift/internal/restclient/model/properties/ResourcePropertyKeys.java
+++ b/src/main/java/com/openshift/internal/restclient/model/properties/ResourcePropertyKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
@@ -16,6 +16,8 @@ public interface ResourcePropertyKeys {
 
     static final String APIVERSION = "apiVersion";
     static final String KIND = "kind";
+    static final String GROUP = "group";
+    static final String VERSION = "version";
 
     static final String ANNOTATIONS = "metadata.annotations";
     static final String CREATION_TIMESTAMP = "metadata.creationTimestamp";
@@ -35,4 +37,5 @@ public interface ResourcePropertyKeys {
     static final String RESOURCE_VERSION = "resourceVersion";
     static final String VALUE = "value";
     static final String TYPE = "type";
+    static final String VERBS = "verbs";
 }

--- a/src/main/java/com/openshift/restclient/ClientBuilder.java
+++ b/src/main/java/com/openshift/restclient/ClientBuilder.java
@@ -263,8 +263,6 @@ public class ClientBuilder {
 
             if (proxySelector != null) {
                 builder.proxySelector(proxySelector);
-            } else {
-            	builder.proxySelector(ProxySelector.getDefault());
             }
 
             if (proxyAuthenticator != null) {

--- a/src/main/java/com/openshift/restclient/ClientBuilder.java
+++ b/src/main/java/com/openshift/restclient/ClientBuilder.java
@@ -263,6 +263,8 @@ public class ClientBuilder {
 
             if (proxySelector != null) {
                 builder.proxySelector(proxySelector);
+            } else {
+            	builder.proxySelector(ProxySelector.getDefault());
             }
 
             if (proxyAuthenticator != null) {
@@ -279,7 +281,7 @@ public class ClientBuilder {
             responseCodeInterceptor.setClient(client);
             authenticator.setClient(client);
             authenticator.setOkClient(okClient);
-
+            factory.setClient(client);
             return client;
         } catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException | CertificateException
                 | IOException e) {

--- a/src/main/java/com/openshift/restclient/IApiTypeMapper.java
+++ b/src/main/java/com/openshift/restclient/IApiTypeMapper.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2016-2019 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -25,6 +25,7 @@ public interface IApiTypeMapper {
     static final String OS_API = "oapi";
     static final String API_GROUPS_API = "apis";
     static final String FWD_SLASH = "/";
+    static final char   DOT = '.';
 
     String getPreferedVersionFor(String endpoint);
 
@@ -66,6 +67,15 @@ public interface IApiTypeMapper {
      * @return true if supported; false otherwise
      */
     boolean isSupported(String version, String kind);
+    
+    /**
+     * Get the type information best matching the version and kind arguments
+     * 
+     * @param apiVersion the optional version (with or without group)
+     * @param kind the type kind
+     * @return the registered type or null
+     */
+    IVersionedType getType(String apiVersion, String kind);
 
     /**
      * The api group for a given set of resources and the versions it supports.
@@ -156,5 +166,42 @@ public interface IApiTypeMapper {
          */
         boolean isSupported(String capability);
 
+    }
+    
+    interface IVersionedType {
+        /**
+         * The prefix of the resource type (e.g. extensions of extensions/v1beta1)
+         * 
+         */
+        String getPrefix();
+        
+        /**
+         * The groupname of the resource type (e.g. extensions of extensions/v1beta1)
+         * 
+         */
+        String getApiGroupName();
+
+        /**
+         * The version of the resource type (e.g. v1)
+         * 
+         */
+        String getVersion();
+        
+        /**
+         * The optional groupname and version of the resource type (e.g. extensions of extensions/v1beta1)
+         * 
+         */
+        default String getApiGroupNameAndVersion() {
+            if (getApiGroupName() != null) {
+                return getApiGroupName() + IApiTypeMapper.FWD_SLASH + getVersion();
+            }
+            return getVersion();
+        }
+        
+        /**
+         * the kind used with this resource type
+         * 
+         */
+        String getKind();
     }
 }

--- a/src/main/java/com/openshift/restclient/ResourceKind.java
+++ b/src/main/java/com/openshift/restclient/ResourceKind.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
@@ -154,5 +154,25 @@ public final class ResourceKind {
     }
 
     private ResourceKind() {
+    }
+
+    public static String[] parse(String kind) {
+        String[] result = new String[2];
+        result[0] = "";
+        if (kind.contains(IApiTypeMapper.FWD_SLASH)) {
+            result[0] = kind.substring(0, kind.indexOf(IApiTypeMapper.FWD_SLASH));
+            kind = kind.substring(kind.indexOf(IApiTypeMapper.FWD_SLASH) + 1);
+        }
+        if (kind.indexOf(IApiTypeMapper.DOT) != (-1)) {
+            String version = kind.substring(0, kind.indexOf(IApiTypeMapper.DOT));
+            if (!result[0].isEmpty()) {
+                result[0] += IApiTypeMapper.FWD_SLASH + version;
+            } else {
+                result[0] = version;
+            }
+            kind = kind.substring(kind.indexOf(IApiTypeMapper.DOT) + 1);
+        }
+        result[1] = kind;
+        return result;
     }
 }

--- a/src/main/resources/k8stypes.properties
+++ b/src/main/resources/k8stypes.properties
@@ -1,0 +1,43 @@
+# Dynamic K8S types registration
+#
+# Syntax is:
+# classname=kind1,kind2,...
+# ex:
+# com.openshift.internal.restclient.model.Build=v1.Build,build.openshift.io/v1.Build
+#
+# Kubernetes API
+com.openshift.internal.restclient.model.ConfigMap=v1.ConfigMap
+com.openshift.internal.restclient.model.KubernetesEvent=v1.Event,events.k8s.io/v1beta1.Event
+com.openshift.internal.restclient.model.LimitRange=v1.LimitRange
+com.openshift.internal.restclient.model.Namespace=v1.Namespace
+com.openshift.internal.restclient.model.volume.PersistentVolume=v1.PersistentVolume
+com.openshift.internal.restclient.model.volume.PersistentVolumeClaim=v1.PersistentVolumeClaim
+com.openshift.internal.restclient.model.Pod=v1.Pod
+com.openshift.internal.restclient.model.ReplicationController=v1.ReplicationController
+com.openshift.internal.restclient.model.ResourceQuota=v1.ResourceQuota
+com.openshift.internal.restclient.model.Secret=v1.Secret
+com.openshift.internal.restclient.model.Service=v1.Service
+com.openshift.internal.restclient.model.ServiceAccount=v1.ServiceAccount
+com.openshift.internal.restclient.model.Status=v1.Status
+
+# OpenShift API
+com.openshift.internal.restclient.model.Build=v1.Build,build.openshift.io/v1.Build
+com.openshift.internal.restclient.model.BuildConfig=v1.BuildConfig,build.openshift.io/v1.BuildConfig
+com.openshift.internal.restclient.model.build.BuildRequest=v1.BuildRequest,build.openshift.io/v1.BuildRequest
+com.openshift.internal.restclient.model.DeploymentConfig=v1.DeploymentConfig,apps.openshift.io/v1.DeploymentConfig
+com.openshift.internal.restclient.model.ImageStream=v1.ImageStream,image.openshift.io/v1.ImageStream
+com.openshift.internal.restclient.model.image.ImageStreamImport=v1.ImageStreamImport,image.openshift.io/v1.ImageStreamImport
+com.openshift.internal.restclient.model.oauth.OAuthAccessToken=v1.OAuthAccessToken,oauth.openshift.io/v1.OAuthAccessToken
+com.openshift.internal.restclient.model.oauth.OAuthAuthorizeToken=v1.OAuthAuthorizeToken,oauth.openshift.io/v1.OAuthAuthorizeToken
+com.openshift.internal.restclient.model.oauth.OAuthClient=v1.OAuthClient,oauth.openshift.io/v1.OAuthClient
+com.openshift.internal.restclient.model.oauth.OAuthClientAuthorization=v1.OAuthClientAuthorization,oauth.openshift.io/v1.OAuthClientAuthorization
+com.openshift.internal.restclient.model.user.OpenShiftIdentity=v1.Identity,user.openshift.io/v1.Identity
+com.openshift.internal.restclient.model.project.OpenshiftProjectRequest=v1.ProjectRequest,project.openshift.io/v1.ProjectRequest
+com.openshift.internal.restclient.model.authorization.OpenshiftRole=v1.Role,authorization.openshift.io/v1.Role
+com.openshift.internal.restclient.model.user.OpenShiftUser=v1.User,user.openshift.io/v1.User
+com.openshift.internal.restclient.model.Project=v1.Project,project.openshift.io/v1.Project
+com.openshift.internal.restclient.model.authorization.RoleBinding=v1.RoleBinding,authorization.openshift.io/v1.RoleBinding
+com.openshift.internal.restclient.model.Route=v1.Route,route.openshift.io/v1.Route
+com.openshift.internal.restclient.model.template.Template=v1.Template,template.openshift.io/v1.Template
+com.openshift.internal.restclient.model.deploy.DeploymentRequest=v1.DeploymentRequest,apps.openshift.io/v1.DeploymentRequest
+com.openshift.internal.restclient.apis.autoscaling.models.Scale=autoscaling/v1.Scale,extensions/v1beta1.Scale

--- a/src/main/resources/k8stypes.properties
+++ b/src/main/resources/k8stypes.properties
@@ -7,6 +7,7 @@
 #
 # Kubernetes API
 com.openshift.internal.restclient.model.ConfigMap=v1.ConfigMap
+com.openshift.internal.restclient.api.models.Endpoints=v1.Endpoints
 com.openshift.internal.restclient.model.KubernetesEvent=v1.Event,events.k8s.io/v1beta1.Event
 com.openshift.internal.restclient.model.LimitRange=v1.LimitRange
 com.openshift.internal.restclient.model.Namespace=v1.Namespace

--- a/src/test/java/com/openshift/internal/restclient/ApiTypeMapperTest.java
+++ b/src/test/java/com/openshift/internal/restclient/ApiTypeMapperTest.java
@@ -38,7 +38,7 @@ public class ApiTypeMapperTest extends TypeMapperFixture {
         IService resource = factory.stub(ResourceKind.SERVICE);
         try {
             getHttpClient().whenRequestTo(TypeMapperFixture.base + "/api").thenThrow(new RuntimeException());
-            assertTrue("Exp. Kube support", mapper.isSupported(resource));
+            assertFalse("Exp. Kube support", mapper.isSupported(resource));
         } catch (RuntimeException e) {
             getHttpClient().whenRequestTo(TypeMapperFixture.base + "/api")
                     .thenReturn(responseOf(TypeMapperFixture.VERSIONS));

--- a/src/test/java/com/openshift/internal/restclient/api/capabilities/PodExecIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/api/capabilities/PodExecIntegrationTest.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import com.openshift.internal.restclient.IntegrationTestHelper;
 import com.openshift.restclient.IClient;
-import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.api.capabilities.IPodExec;
 import com.openshift.restclient.capability.CapabilityVisitor;
 import com.openshift.restclient.capability.IStoppable;
@@ -102,8 +101,7 @@ public class PodExecIntegrationTest {
     @Before
     public void setUp() throws Exception {
         IClient client = helper.createClientForBasicAuth();
-        List<IPod> allPods = client.list(ResourceKind.POD, IntegrationTestHelper.getDefaultNamespace());
-        this.pod = helper.getDockerRegistryPod(allPods);
+        this.pod = helper.getDockerRegistryPod(client);
         assertNotNull("Need a pod to continue the test. Expected to find the registry", pod);
     }
 

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/OpenshiftBinaryRSyncRetrievalIntegrationTest.java
@@ -1,4 +1,3 @@
-package com.openshift.internal.restclient.capability.resources;
 /*******************************************************************************
  * Copyright (c) 2015-2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
@@ -9,6 +8,8 @@ package com.openshift.internal.restclient.capability.resources;
  * Contributors:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
+
+package com.openshift.internal.restclient.capability.resources;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
@@ -34,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import com.openshift.internal.restclient.IntegrationTestHelper;
 import com.openshift.internal.restclient.api.capabilities.PodExecIntegrationTest;
 import com.openshift.restclient.IClient;
-import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.api.capabilities.IPodExec;
 import com.openshift.restclient.capability.CapabilityVisitor;
 import com.openshift.restclient.capability.IBinaryCapability.SkipTlsVerify;
@@ -76,8 +76,7 @@ public class OpenshiftBinaryRSyncRetrievalIntegrationTest {
         // given
         this.helper.setOpenShiftBinarySystemProperty();
         this.client = helper.createClientForBasicAuth();
-        List<IPod> allPods = client.list(ResourceKind.POD, IntegrationTestHelper.getDefaultNamespace());
-        this.pod = helper.getDockerRegistryPod(allPods);
+        this.pod = helper.getDockerRegistryPod(client);
         assertNotNull("Did not find the registry pod to which to rsync", pod);
     }
 

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/PodLogRetrievalAsyncIntegrationTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/PodLogRetrievalAsyncIntegrationTest.java
@@ -14,7 +14,6 @@ package com.openshift.internal.restclient.capability.resources;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -24,7 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import com.openshift.internal.restclient.DefaultClient;
 import com.openshift.internal.restclient.IntegrationTestHelper;
-import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.capability.CapabilityVisitor;
 import com.openshift.restclient.capability.IStoppable;
 import com.openshift.restclient.capability.resources.IPodLogRetrievalAsync;
@@ -43,8 +41,7 @@ public class PodLogRetrievalAsyncIntegrationTest {
     public void testAsyncLogRetrieval() throws Exception {
         latch = new CountDownLatch(2);
         DefaultClient client = (DefaultClient) helper.createClientForBasicAuth();
-        List<IPod> allPods = client.list(ResourceKind.POD, IntegrationTestHelper.getDefaultNamespace());
-        IPod pod = helper.getDockerRegistryPod(allPods);
+        IPod pod = helper.getDockerRegistryPod(client);
         assertNotNull("Need a pod to continue the test. Expected to find the registry", pod);
 
         final String container = pod.getContainers().iterator().next().getName();

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/ProjectTemplateProcessingTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/ProjectTemplateProcessingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
@@ -28,7 +28,11 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.openshift.internal.restclient.ResourceFactory;
+import com.openshift.restclient.IApiTypeMapper;
+import com.openshift.restclient.IApiTypeMapper.IVersionedApiResource;
+import com.openshift.restclient.IApiTypeMapper.IVersionedType;
 import com.openshift.restclient.IClient;
+import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.capability.resources.IProjectTemplateProcessing;
 import com.openshift.restclient.capability.server.ITemplateProcessing;
 import com.openshift.restclient.model.IList;
@@ -93,6 +97,91 @@ public class ProjectTemplateProcessingTest {
         when(client.create(any(IList.class), anyString())).thenReturn(resources);
         when(client.getResourceFactory()).thenReturn(new ResourceFactory(client) {
         });
+        IApiTypeMapper mapper = mock(IApiTypeMapper.class);
+        when(client.adapt(IApiTypeMapper.class)).thenReturn(mapper);
+        when(mapper.getType(anyString(), eq(ResourceKind.TEMPLATE))).thenReturn(new IVersionedType() {
+            
+            @Override
+            public String getVersion() {
+                return "v1";
+            }
+            
+            @Override
+            public String getPrefix() {
+                return null;
+            }
+            
+            @Override
+            public String getKind() {
+                return ResourceKind.TEMPLATE;
+            }
+            
+            @Override
+            public String getApiGroupName() {
+                return null;
+            }
+        });
+        when(mapper.getType(anyString(), eq(ResourceKind.DEPLOYMENT_CONFIG))).thenReturn(new IVersionedType() {
+            
+            @Override
+            public String getVersion() {
+                return "v1";
+            }
+            
+            @Override
+            public String getPrefix() {
+                return null;
+            }
+            
+            @Override
+            public String getKind() {
+                return ResourceKind.DEPLOYMENT_CONFIG;
+            }
+            
+            @Override
+            public String getApiGroupName() {
+                return null;
+            }
+        });
+        when(mapper.getEndpointFor(anyString(), eq(ResourceKind.DEPLOYMENT_CONFIG))).thenReturn(new IVersionedApiResource() {
+            
+            @Override
+            public boolean isSupported(String capability) {
+                return true;
+            }
+            
+            @Override
+            public boolean isNamespaced() {
+                return true;
+            }
+            
+            @Override
+            public String getVersion() {
+                return "v1";
+            }
+            
+            @Override
+            public String getPrefix() {
+                return null;
+            }
+            
+            @Override
+            public String getName() {                // TODO Auto-generated method stub
+                return null;
+            }
+            
+            @Override
+            public String getKind() {
+                return ResourceKind.DEPLOYMENT_CONFIG;
+            }
+            
+            @Override
+            public String getApiGroupName() {
+                return "v1";
+            }
+        });
+
+        
         ITemplate template = new ResourceFactory(client) {
         }.create(Samples.V1_TEMPLATE.getContentAsString());
 

--- a/src/test/java/com/openshift/internal/restclient/capability/resources/UpdateableCapabilityTest.java
+++ b/src/test/java/com/openshift/internal/restclient/capability/resources/UpdateableCapabilityTest.java
@@ -11,6 +11,8 @@ package com.openshift.internal.restclient.capability.resources;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
@@ -21,6 +23,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.openshift.internal.restclient.IntegrationTestHelper;
 import com.openshift.internal.restclient.ResourceFactory;
+import com.openshift.restclient.IApiTypeMapper;
+import com.openshift.restclient.IApiTypeMapper.IVersionedType;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.IResourceFactory;
 import com.openshift.restclient.ResourceKind;
@@ -33,12 +37,37 @@ public class UpdateableCapabilityTest {
 
     @Mock
     private IClient client;
+    @Mock
+    private IApiTypeMapper mapper;
     private IService service;
     private IResourceFactory factory;
 
     @Before
     public void setup() {
         when(client.getOpenShiftAPIVersion()).thenReturn("v1");
+        when(client.adapt(IApiTypeMapper.class)).thenReturn(mapper);
+        when(mapper.getType(anyString(), eq(ResourceKind.SERVICE))).thenReturn(new IVersionedType() {
+            
+            @Override
+            public String getVersion() {
+                return "v1";
+            }
+            
+            @Override
+            public String getPrefix() {
+                return null;
+            }
+            
+            @Override
+            public String getKind() {
+                return ResourceKind.SERVICE;
+            }
+            
+            @Override
+            public String getApiGroupName() {
+                return null;
+            }
+        });
         this.factory = new ResourceFactory(client);
         this.service = factory.stub(ResourceKind.SERVICE, "foo", IntegrationTestHelper.getDefaultNamespace());
         service.setAnnotation("foo", "bar");

--- a/src/test/java/com/openshift/internal/restclient/model/ProjectTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/ProjectTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
@@ -12,6 +12,7 @@ package com.openshift.internal.restclient.model;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +27,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.openshift.internal.restclient.OpenShiftAPIVersion;
 import com.openshift.internal.restclient.ResourceFactory;
+import com.openshift.restclient.IApiTypeMapper;
+import com.openshift.restclient.IApiTypeMapper.IVersionedType;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.model.IService;
@@ -39,6 +42,30 @@ public class ProjectTest {
 
     @Before
     public void setup() {
+        IApiTypeMapper mapper = mock(IApiTypeMapper.class);
+        when(client.adapt(IApiTypeMapper.class)).thenReturn(mapper);
+        when(mapper.getType(anyString(), eq(ResourceKind.PROJECT))).thenReturn(new IVersionedType() {
+            
+            @Override
+            public String getVersion() {
+                return "v1";
+            }
+            
+            @Override
+            public String getPrefix() {
+                return null;
+            }
+            
+            @Override
+            public String getKind() {
+                return ResourceKind.PROJECT;
+            }
+            
+            @Override
+            public String getApiGroupName() {
+                return null;
+            }
+        });
         project = new ResourceFactory(client) {
         }.create(OpenShiftAPIVersion.v1.toString(), ResourceKind.PROJECT);
         project.setName("aprojectname");

--- a/src/test/java/com/openshift/internal/restclient/model/ServiceTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/ServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
@@ -27,6 +27,8 @@ import org.junit.Test;
 
 import com.openshift.internal.restclient.OpenShiftAPIVersion;
 import com.openshift.internal.restclient.ResourceFactory;
+import com.openshift.restclient.IApiTypeMapper;
+import com.openshift.restclient.IApiTypeMapper.IVersionedType;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.IResourceFactory;
 import com.openshift.restclient.ResourceKind;
@@ -38,13 +40,37 @@ public class ServiceTest {
 
     private IService service;
     private IClient client;
+    private IApiTypeMapper mapper;
 
     @Before
     public void setup() {
         client = mock(IClient.class);
+        mapper = mock(IApiTypeMapper.class);
         when(client.getOpenShiftAPIVersion()).thenReturn(OpenShiftAPIVersion.v1.name());
-        IResourceFactory factory = new ResourceFactory(client) {
-        };
+        when(client.adapt(IApiTypeMapper.class)).thenReturn(mapper);
+        when(mapper.getType(anyString(), eq(ResourceKind.SERVICE))).thenReturn(new IVersionedType() {
+            
+            @Override
+            public String getVersion() {
+                return "v1";
+            }
+            
+            @Override
+            public String getPrefix() {
+                return null;
+            }
+            
+            @Override
+            public String getKind() {
+                return ResourceKind.SERVICE;
+            }
+            
+            @Override
+            public String getApiGroupName() {
+                return null;
+            }
+        });
+        IResourceFactory factory = new ResourceFactory(client);
         service = factory.stub(ResourceKind.SERVICE, OpenShiftAPIVersion.v1.name());
     }
 

--- a/src/test/java/com/openshift/internal/restclient/model/v1/BuildConfigTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/BuildConfigTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2018 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
@@ -12,6 +12,8 @@ package com.openshift.internal.restclient.model.v1;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,6 +33,8 @@ import com.openshift.internal.restclient.model.build.GitBuildSource;
 import com.openshift.internal.restclient.model.build.ImageChangeTrigger;
 import com.openshift.internal.restclient.model.build.SourceBuildStrategy;
 import com.openshift.internal.restclient.model.build.WebhookTrigger;
+import com.openshift.restclient.IApiTypeMapper;
+import com.openshift.restclient.IApiTypeMapper.IVersionedType;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.images.DockerImageURI;
@@ -55,6 +59,30 @@ public class BuildConfigTest {
     @BeforeClass
     public static void setup() throws Exception {
         client = mock(IClient.class);
+        IApiTypeMapper mapper = mock(IApiTypeMapper.class);
+        when(client.adapt(IApiTypeMapper.class)).thenReturn(mapper);
+        when(mapper.getType(anyString(), eq(ResourceKind.PVC))).thenReturn(new IVersionedType() {
+            
+            @Override
+            public String getVersion() {
+                return "v1";
+            }
+            
+            @Override
+            public String getPrefix() {
+                return null;
+            }
+            
+            @Override
+            public String getKind() {
+                return ResourceKind.BUILD_CONFIG;
+            }
+            
+            @Override
+            public String getApiGroupName() {
+                return null;
+            }
+        });
         when(client.getBaseURL()).thenReturn(new URL("https://localhost:8443"));
         when(client.getOpenShiftAPIVersion()).thenReturn(VERSION);
         ModelNode node = ModelNode.fromJSONString(Samples.V1_BUILD_CONFIG.getContentAsString());

--- a/src/test/java/com/openshift/internal/restclient/model/v1/ConfigMapTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/ConfigMapTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
@@ -10,7 +10,10 @@
 package com.openshift.internal.restclient.model.v1;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
@@ -21,6 +24,8 @@ import org.junit.Test;
 import com.openshift.internal.restclient.ResourceFactory;
 import com.openshift.internal.restclient.model.ConfigMap;
 import com.openshift.internal.restclient.model.properties.ResourcePropertiesRegistry;
+import com.openshift.restclient.IApiTypeMapper;
+import com.openshift.restclient.IApiTypeMapper.IVersionedType;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.model.IConfigMap;
@@ -38,6 +43,30 @@ public class ConfigMapTest {
     @Before
     public void setUp() {
         client = mock(IClient.class);
+        IApiTypeMapper mapper = mock(IApiTypeMapper.class);
+        when(client.adapt(IApiTypeMapper.class)).thenReturn(mapper);
+        when(mapper.getType(anyString(), eq(ResourceKind.CONFIG_MAP))).thenReturn(new IVersionedType() {
+            
+            @Override
+            public String getVersion() {
+                return "v1";
+            }
+            
+            @Override
+            public String getPrefix() {
+                return null;
+            }
+            
+            @Override
+            public String getKind() {
+                return ResourceKind.CONFIG_MAP;
+            }
+            
+            @Override
+            public String getApiGroupName() {
+                return null;
+            }
+        });
         ModelNode node = ModelNode.fromJSONString(Samples.V1_CONFIG_MAP.getContentAsString());
         configMap = new ConfigMap(node, client,
                 ResourcePropertiesRegistry.getInstance().get(VERSION, ResourceKind.CONFIG_MAP));

--- a/src/test/java/com/openshift/internal/restclient/model/v1/PVCTest.java
+++ b/src/test/java/com/openshift/internal/restclient/model/v1/PVCTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
@@ -11,7 +11,10 @@ package com.openshift.internal.restclient.model.v1;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
@@ -19,7 +22,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.openshift.internal.restclient.ResourceFactory;
+import com.openshift.restclient.IApiTypeMapper;
+import com.openshift.restclient.IApiTypeMapper.IVersionedType;
 import com.openshift.restclient.IClient;
+import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.model.volume.IPersistentVolumeClaim;
 import com.openshift.restclient.model.volume.PVCAccessModes;
 import com.openshift.restclient.utils.Samples;
@@ -32,6 +38,30 @@ public class PVCTest {
     @Before
     public void setup() {
         IClient client = mock(IClient.class);
+        IApiTypeMapper mapper = mock(IApiTypeMapper.class);
+        when(client.adapt(IApiTypeMapper.class)).thenReturn(mapper);
+        when(mapper.getType(anyString(), eq(ResourceKind.PVC))).thenReturn(new IVersionedType() {
+            
+            @Override
+            public String getVersion() {
+                return "v1";
+            }
+            
+            @Override
+            public String getPrefix() {
+                return null;
+            }
+            
+            @Override
+            public String getKind() {
+                return ResourceKind.PVC;
+            }
+            
+            @Override
+            public String getApiGroupName() {
+                return null;
+            }
+        });
         claim = new ResourceFactory(client).create(Samples.V1_PVC.getContentAsString());
         assertEquals(V1, claim.getApiVersion());
     }

--- a/src/test/java/com/openshift/restclient/WatchClientIntegrationTest.java
+++ b/src/test/java/com/openshift/restclient/WatchClientIntegrationTest.java
@@ -68,7 +68,7 @@ public class WatchClientIntegrationTest {
         executor.shutdownNow();
     }
 
-    @Test(timeout = IntegrationTestHelper.TEST_TIMEOUT)
+    @Test(timeout = IntegrationTestHelper.TEST_LONG_TIMEOUT)
     public void test() throws Exception {
         List<ChangeType> results = new ArrayList<>();
         CountDownLatch latch = new CountDownLatch(KINDS.length);

--- a/src/test/java/com/openshift/restclient/model/MocksFactory.java
+++ b/src/test/java/com/openshift/restclient/model/MocksFactory.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2016-2019 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -11,6 +11,8 @@
 
 package com.openshift.restclient.model;
 
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
@@ -19,8 +21,11 @@ import org.mockito.Mockito;
 
 import com.openshift.internal.restclient.OpenShiftAPIVersion;
 import com.openshift.internal.restclient.ResourceFactory;
+import com.openshift.restclient.IApiTypeMapper;
+import com.openshift.restclient.IApiTypeMapper.IVersionedType;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.IResourceFactory;
+import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.utils.Samples;
 
 public class MocksFactory {
@@ -35,6 +40,30 @@ public class MocksFactory {
     public MocksFactory(IClient client) {
         this.client = client;
         this.factory = new ResourceFactory(client);
+        IApiTypeMapper mapper = Mockito.mock(IApiTypeMapper.class);
+        when(client.adapt(IApiTypeMapper.class)).thenReturn(mapper);
+        when(mapper.getType(anyString(), eq(ResourceKind.BUILD_CONFIG))).thenReturn(new IVersionedType() {
+            
+            @Override
+            public String getVersion() {
+                return "v1";
+            }
+            
+            @Override
+            public String getPrefix() {
+                return null;
+            }
+            
+            @Override
+            public String getKind() {
+                return ResourceKind.BUILD_CONFIG;
+            }
+            
+            @Override
+            public String getApiGroupName() {
+                return null;
+            }
+        });
     }
 
     public IClient getClient() {

--- a/src/test/java/com/openshift/restclient/utils/Samples.java
+++ b/src/test/java/com/openshift/restclient/utils/Samples.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2014-2015 Red Hat, Inc. 
+ * Copyright (c) 2014-2019 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -59,7 +59,8 @@ public enum Samples {
     V1_SERVICE("openshift3/v1_service.json"),
     V1_SERVICE_ACCOUNT("openshift3/v1_service_account.json"),
     V1_Status("openshift3/v1_status.json"),
-    V1_TEMPLATE("openshift3/v1_template.json"), 
+    V1_TEMPLATE("openshift3/v1_template.json"),
+    GROUP_TEMPLATE("openshift3/group_template.json"),
     V1_USER("openshift3/v1_user.json"),
     V1_IDENTITY("openshift3/v1_identity.json"),
     V1_GROUP("openshift3/v1_group.json"),

--- a/src/test/resources/samples/openshift3/api_v1_endpoint.json
+++ b/src/test/resources/samples/openshift3/api_v1_endpoint.json
@@ -4,183 +4,492 @@
   "resources": [
     {
       "name": "bindings",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Binding"
+      "kind": "Binding",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "componentstatuses",
+      "singularName": "",
       "namespaced": false,
-      "kind": "ComponentStatus"
+      "kind": "ComponentStatus",
+      "verbs": [
+        "get",
+        "list"
+      ],
+      "shortNames": [
+        "cs"
+      ]
     },
     {
       "name": "configmaps",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ConfigMap"
+      "kind": "ConfigMap",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "cm"
+      ]
     },
     {
       "name": "endpoints",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Endpoints"
+      "kind": "Endpoints",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "ep"
+      ]
     },
     {
       "name": "events",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Event"
+      "kind": "Event",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "ev"
+      ]
     },
     {
       "name": "limitranges",
+      "singularName": "",
       "namespaced": true,
-      "kind": "LimitRange"
+      "kind": "LimitRange",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "limits"
+      ]
     },
     {
       "name": "namespaces",
+      "singularName": "",
       "namespaced": false,
-      "kind": "Namespace"
+      "kind": "Namespace",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "ns"
+      ]
     },
     {
       "name": "namespaces/finalize",
+      "singularName": "",
       "namespaced": false,
-      "kind": "Namespace"
+      "kind": "Namespace",
+      "verbs": [
+        "update"
+      ]
     },
     {
       "name": "namespaces/status",
+      "singularName": "",
       "namespaced": false,
-      "kind": "Namespace"
+      "kind": "Namespace",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "nodes",
+      "singularName": "",
       "namespaced": false,
-      "kind": "Node"
+      "kind": "Node",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "no"
+      ]
     },
     {
       "name": "nodes/proxy",
+      "singularName": "",
       "namespaced": false,
-      "kind": "Node"
+      "kind": "Node",
+      "verbs": []
     },
     {
       "name": "nodes/status",
+      "singularName": "",
       "namespaced": false,
-      "kind": "Node"
+      "kind": "Node",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "persistentvolumeclaims",
+      "singularName": "",
       "namespaced": true,
-      "kind": "PersistentVolumeClaim"
+      "kind": "PersistentVolumeClaim",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "pvc"
+      ]
     },
     {
       "name": "persistentvolumeclaims/status",
+      "singularName": "",
       "namespaced": true,
-      "kind": "PersistentVolumeClaim"
+      "kind": "PersistentVolumeClaim",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "persistentvolumes",
+      "singularName": "",
       "namespaced": false,
-      "kind": "PersistentVolume"
+      "kind": "PersistentVolume",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "pv"
+      ]
     },
     {
       "name": "persistentvolumes/status",
+      "singularName": "",
       "namespaced": false,
-      "kind": "PersistentVolume"
+      "kind": "PersistentVolume",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "pods",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Pod"
+      "kind": "Pod",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "po"
+      ],
+      "categories": [
+        "all"
+      ]
     },
     {
       "name": "pods/attach",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Pod"
+      "kind": "Pod",
+      "verbs": []
     },
     {
       "name": "pods/binding",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Binding"
+      "kind": "Binding",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "pods/eviction",
+      "singularName": "",
+      "namespaced": true,
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "Eviction",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "pods/exec",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Pod"
+      "kind": "Pod",
+      "verbs": []
     },
     {
       "name": "pods/log",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Pod"
+      "kind": "Pod",
+      "verbs": [
+        "get"
+      ]
     },
     {
       "name": "pods/portforward",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Pod"
+      "kind": "Pod",
+      "verbs": []
     },
     {
       "name": "pods/proxy",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Pod"
+      "kind": "Pod",
+      "verbs": []
     },
     {
       "name": "pods/status",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Pod"
+      "kind": "Pod",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "podtemplates",
+      "singularName": "",
       "namespaced": true,
-      "kind": "PodTemplate"
+      "kind": "PodTemplate",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "replicationcontrollers",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ReplicationController"
+      "kind": "ReplicationController",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "rc"
+      ],
+      "categories": [
+        "all"
+      ]
     },
     {
       "name": "replicationcontrollers/scale",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Scale"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "replicationcontrollers/status",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ReplicationController"
+      "kind": "ReplicationController",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "resourcequotas",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ResourceQuota"
+      "kind": "ResourceQuota",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "quota"
+      ]
     },
     {
       "name": "resourcequotas/status",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ResourceQuota"
+      "kind": "ResourceQuota",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "secrets",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Secret"
-    },
-    {
-      "name": "securitycontextconstraints",
-      "namespaced": false,
-      "kind": "SecurityContextConstraints"
+      "kind": "Secret",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "serviceaccounts",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ServiceAccount"
+      "kind": "ServiceAccount",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "sa"
+      ]
     },
     {
       "name": "services",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Service"
+      "kind": "Service",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "svc"
+      ],
+      "categories": [
+        "all"
+      ]
     },
     {
       "name": "services/proxy",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Service"
+      "kind": "Service",
+      "verbs": []
     },
     {
       "name": "services/status",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Service"
+      "kind": "Service",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     }
   ]
 }

--- a/src/test/resources/samples/openshift3/apis_endpoint_extensions.json
+++ b/src/test/resources/samples/openshift3/apis_endpoint_extensions.json
@@ -4,88 +4,214 @@
   "resources": [
     {
       "name": "daemonsets",
+      "singularName": "",
       "namespaced": true,
-      "kind": "DaemonSet"
+      "kind": "DaemonSet",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "ds"
+      ]
     },
     {
       "name": "daemonsets/status",
+      "singularName": "",
       "namespaced": true,
-      "kind": "DaemonSet"
+      "kind": "DaemonSet",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "deployments",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Deployment"
+      "kind": "Deployment",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "deploy"
+      ]
     },
     {
       "name": "deployments/rollback",
+      "singularName": "",
       "namespaced": true,
-      "kind": "DeploymentRollback"
+      "kind": "DeploymentRollback",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "deployments/scale",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "deployments/status",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Deployment"
-    },
-    {
-      "name": "horizontalpodautoscalers",
-      "namespaced": true,
-      "kind": "HorizontalPodAutoscaler"
-    },
-    {
-      "name": "horizontalpodautoscalers/status",
-      "namespaced": true,
-      "kind": "HorizontalPodAutoscaler"
+      "kind": "Deployment",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "ingresses",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Ingress"
+      "kind": "Ingress",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "ing"
+      ]
     },
     {
       "name": "ingresses/status",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Ingress"
+      "kind": "Ingress",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
-      "name": "jobs",
+      "name": "networkpolicies",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Job"
+      "kind": "NetworkPolicy",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "netpol"
+      ]
     },
     {
-      "name": "jobs/status",
-      "namespaced": true,
-      "kind": "Job"
+      "name": "podsecuritypolicies",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "PodSecurityPolicy",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "psp"
+      ]
     },
     {
       "name": "replicasets",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ReplicaSet"
+      "kind": "ReplicaSet",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "rs"
+      ]
     },
     {
       "name": "replicasets/scale",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "replicasets/status",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ReplicaSet"
+      "kind": "ReplicaSet",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "replicationcontrollers",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ReplicationControllerDummy"
+      "kind": "ReplicationControllerDummy",
+      "verbs": []
     },
     {
       "name": "replicationcontrollers/scale",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Scale"
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     }
   ]
 }

--- a/src/test/resources/samples/openshift3/group_template.json
+++ b/src/test/resources/samples/openshift3/group_template.json
@@ -1,0 +1,450 @@
+{
+    "kind": "Template",
+    "apiVersion": "template.openshift.io/v1",
+    "metadata": {
+        "name": "ruby-helloworld-sample",
+        "namespace": "myproject",
+        "selfLink": "/oapi/v1/namespaces/myproject/templates/ruby-helloworld-sample",
+        "uid": "870dab76-38c7-11e6-8e5e-3c970e32f15a",
+        "resourceVersion": "86618",
+        "creationTimestamp": "2016-06-22T22:20:29Z",
+        "labels": {
+            "abc": "xyz",
+            "foo": "bar"
+        },
+        "annotations": {
+            "description": "This example shows how to create a simple ruby application in openshift origin v3",
+            "iconClass": "icon-ruby",
+            "tags": "instant-app,ruby,mysql"
+        }
+    },
+    "objects": [
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "frontend",
+                "creationTimestamp": null
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name": "web",
+                        "protocol": "TCP",
+                        "port": 5432,
+                        "targetPort": 8080,
+                        "nodePort": 0
+                    }
+                ],
+                "selector": {
+                    "name": "frontend"
+                },
+                "portalIP": "",
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "route-edge",
+                "creationTimestamp": null
+            },
+            "spec": {
+                "host": "www.example.com",
+                "to": {
+                    "kind": "Service",
+                    "name": "frontend"
+                },
+                "tls": {
+                    "termination": "edge",
+                    "certificate": "-----BEGIN CERTIFICATE-----\nMIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx\nCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl\nZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3\ndy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu\nY29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP\nd3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq\nhkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx\nEDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv\ngu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm\n47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M\nmNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC\nMAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd\nTMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m\nV7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc\nyfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j\njhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q\n+Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=\n-----END CERTIFICATE-----",
+                    "key": "-----BEGIN PRIVATE KEY-----\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMrvgu6ZTTefNN7j\njiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm47VRx5Qrf/YL\nXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1MmNrQUgZyQC6X\nIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAECgYEAnxOjEj/vrLNLMZE1Q9H7PZVF\nWdP/JQVNvQ7tCpZ3ZdjxHwkvf//aQnuxS5yX2Rnf37BS/TZu+TIkK4373CfHomSx\nUTAn2FsLmOJljupgGcoeLx5K5nu7B7rY5L1NHvdpxZ4YjeISrRtEPvRakllENU5y\ngJE8c2eQOx08ZSRE4TkCQQD7dws2/FldqwdjJucYijsJVuUdoTqxP8gWL6bB251q\nelP2/a6W2elqOcWId28560jG9ZS3cuKvnmu/4LG88vZFAkEAzphrH3673oTsHN+d\nuBd5uyrlnGjWjuiMKv2TPITZcWBjB8nJDSvLneHF59MYwejNNEof2tRjgFSdImFH\nmi995wJBAMtPjW6wiqRz0i41VuT9ZgwACJBzOdvzQJfHgSD9qgFb1CU/J/hpSRIM\nkYvrXK9MbvQFvG6x4VuyT1W8mpe1LK0CQAo8VPpffhFdRpF7psXLK/XQ/0VLkG3O\nKburipLyBg/u9ZkaL0Ley5zL5dFBjTV2Qkx367Ic2b0u9AYTCcgi2DsCQQD3zZ7B\nv7BOm7MkylKokY2MduFFXU0Bxg6pfZ7q3rvg8gqhUFbaMStPRYg6myiDiW/JfLhF\nTcFT4touIo7oriFJ\n-----END PRIVATE KEY-----",
+                    "caCertificate": "-----BEGIN CERTIFICATE-----\nMIIEFzCCAv+gAwIBAgIJALK1iUpF2VQLMA0GCSqGSIb3DQEBBQUAMIGhMQswCQYD\nVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoG\nA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UECwwHVGVzdCBDQTEaMBgG\nA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG9w0BCQEWE2V4YW1wbGVA\nZXhhbXBsZS5jb20wHhcNMTUwMTEyMTQxNTAxWhcNMjUwMTA5MTQxNTAxWjCBoTEL\nMAkGA1UEBhMCVVMxCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkx\nHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0Ex\nGjAYBgNVBAMMEXd3dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFt\ncGxlQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\nw2rK1J2NMtQj0KDug7g7HRKl5jbf0QMkMKyTU1fBtZ0cCzvsF4CqV11LK4BSVWaK\nrzkaXe99IVJnH8KdOlDl5Dh/+cJ3xdkClSyeUT4zgb6CCBqg78ePp+nN11JKuJlV\nIG1qdJpB1J5O/kCLsGcTf7RS74MtqMFo96446Zvt7YaBhWPz6gDaO/TUzfrNcGLA\nEfHVXkvVWqb3gqXUztZyVex/gtP9FXQ7gxTvJml7UkmT0VAFjtZnCqmFxpLZFZ15\n+qP9O7Q2MpsGUO/4vDAuYrKBeg1ZdPSi8gwqUP2qWsGd9MIWRv3thI2903BczDc7\nr8WaIbm37vYZAS9G56E4+wIDAQABo1AwTjAdBgNVHQ4EFgQUugLrSJshOBk5TSsU\nANs4+SmJUGwwHwYDVR0jBBgwFoAUugLrSJshOBk5TSsUANs4+SmJUGwwDAYDVR0T\nBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAaMJ33zAMV4korHo5aPfayV3uHoYZ\n1ChzP3eSsF+FjoscpoNSKs91ZXZF6LquzoNezbfiihK4PYqgwVD2+O0/Ty7UjN4S\nqzFKVR4OS/6lCJ8YncxoFpTntbvjgojf1DEataKFUN196PAANc3yz8cWHF4uvjPv\nWkgFqbIjb+7D1YgglNyovXkRDlRZl0LD1OQ0ZWhd4Ge1qx8mmmanoBeYZ9+DgpFC\nj9tQAbS867yeOryNe7sEOIpXAAqK/DTu0hB6+ySsDfMo4piXCc2aA/eI2DCuw08e\nw17Dz9WnupZjVdwTKzDhFgJZMLDqn37HQnT6EemLFqbcR0VPEnfyhDtZIQ==\n-----END CERTIFICATE-----"
+                }
+            },
+            "status": {}
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "origin-ruby-sample",
+                "creationTimestamp": null
+            },
+            "spec": {},
+            "status": {
+                "dockerImageRepository": ""
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "ruby-20-centos7",
+                "creationTimestamp": null
+            },
+            "spec": {
+                "dockerImageRepository": "openshift/ruby-20-centos7"
+            },
+            "status": {
+                "dockerImageRepository": ""
+            }
+        },
+        {
+            "kind": "BuildConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "ruby-sample-build",
+                "creationTimestamp": null,
+                "labels": {
+                    "name": "ruby-sample-build"
+                }
+            },
+            "spec": {
+                "triggers": [
+                    {
+                        "type": "github",
+                        "github": {
+                            "secret": "secret101"
+                        }
+                    },
+                    {
+                        "type": "generic",
+                        "generic": {
+                            "secret": "secret101"
+                        }
+                    },
+                    {
+                        "type": "imageChange",
+                        "imageChange": {}
+                    }
+                ],
+                "source": {
+                    "type": "Git",
+                    "git": {
+                        "uri": "git://github.com/openshift/ruby-hello-world.git"
+                    }
+                },
+                "strategy": {
+                    "type": "Source",
+                    "sourceStrategy": {
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "ruby-20-centos7:latest"
+                        },
+                        "incremental": true
+                    }
+                },
+                "output": {
+                    "to": {
+                        "kind": "ImageStreamTag",
+                        "name": "origin-ruby-sample:latest"
+                    }
+                },
+                "resources": {}
+            },
+            "status": {
+                "lastVersion": 0
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "frontend",
+                "creationTimestamp": null
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Rolling",
+                    "rollingParams": {
+                        "updatePeriodSeconds": 1,
+                        "intervalSeconds": 1,
+                        "timeoutSeconds": 120,
+                        "pre": {
+                            "failurePolicy": "Abort",
+                            "execNewPod": {
+                                "command": [
+                                    "/bin/true"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CUSTOM_VAR1",
+                                        "value": "custom_value1"
+                                    }
+                                ],
+                                "containerName": "ruby-helloworld"
+                            }
+                        },
+                        "post": {
+                            "failurePolicy": "Ignore",
+                            "execNewPod": {
+                                "command": [
+                                    "/bin/false"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CUSTOM_VAR2",
+                                        "value": "custom_value2"
+                                    }
+                                ],
+                                "containerName": "ruby-helloworld"
+                            }
+                        }
+                    },
+                    "resources": {}
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "ruby-helloworld"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "origin-ruby-sample:latest"
+                            },
+                            "lastTriggeredImage": ""
+                        }
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 2,
+                "selector": {
+                    "name": "frontend"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "name": "frontend"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "ruby-helloworld",
+                                "image": "origin-ruby-sample",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "ADMIN_USERNAME",
+                                        "value": "${ADMIN_USERNAME}"
+                                    },
+                                    {
+                                        "name": "ADMIN_PASSWORD",
+                                        "value": "${ADMIN_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MYSQL_USER",
+                                        "value": "${MYSQL_USER}"
+                                    },
+                                    {
+                                        "name": "MYSQL_PASSWORD",
+                                        "value": "${MYSQL_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MYSQL_DATABASE",
+                                        "value": "${MYSQL_DATABASE}"
+                                    }
+                                ],
+                                "resources": {},
+                                "terminationMessagePath": "/dev/termination-log",
+                                "imagePullPolicy": "IfNotPresent",
+                                "capabilities": {},
+                                "securityContext": {
+                                    "capabilities": {},
+                                    "privileged": false
+                                }
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        "dnsPolicy": "ClusterFirst",
+                        "serviceAccount": ""
+                    }
+                }
+            },
+            "status": {}
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "database",
+                "creationTimestamp": null
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name": "db",
+                        "protocol": "TCP",
+                        "port": 5434,
+                        "targetPort": 3306,
+                        "nodePort": 0
+                    }
+                ],
+                "selector": {
+                    "name": "database"
+                },
+                "portalIP": "",
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "database",
+                "creationTimestamp": null
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate",
+                    "recreateParams": {
+                        "pre": {
+                            "failurePolicy": "Abort",
+                            "execNewPod": {
+                                "command": [
+                                    "/bin/true"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CUSTOM_VAR1",
+                                        "value": "custom_value1"
+                                    }
+                                ],
+                                "containerName": "ruby-helloworld-database"
+                            }
+                        },
+                        "post": {
+                            "failurePolicy": "Ignore",
+                            "execNewPod": {
+                                "command": [
+                                    "/bin/false"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CUSTOM_VAR2",
+                                        "value": "custom_value2"
+                                    }
+                                ],
+                                "containerName": "ruby-helloworld-database"
+                            }
+                        }
+                    },
+                    "resources": {}
+                },
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "name": "database"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "name": "database"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "ruby-helloworld-database",
+                                "image": "openshift/mysql-55-centos7:latest",
+                                "ports": [
+                                    {
+                                        "containerPort": 3306,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "MYSQL_USER",
+                                        "value": "${MYSQL_USER}"
+                                    },
+                                    {
+                                        "name": "MYSQL_PASSWORD",
+                                        "value": "${MYSQL_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MYSQL_DATABASE",
+                                        "value": "${MYSQL_DATABASE}"
+                                    }
+                                ],
+                                "resources": {},
+                                "terminationMessagePath": "/dev/termination-log",
+                                "imagePullPolicy": "Always",
+                                "capabilities": {},
+                                "securityContext": {
+                                    "capabilities": {},
+                                    "privileged": false
+                                }
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        "dnsPolicy": "ClusterFirst",
+                        "serviceAccount": ""
+                    }
+                }
+            },
+            "status": {}
+        }
+    ],
+    "parameters": [
+        {
+            "name": "ADMIN_USERNAME",
+            "description": "administrator username",
+            "generate": "expression",
+            "from": "admin[A-Z0-9]{3}"
+        },
+        {
+            "name": "ADMIN_PASSWORD",
+            "description": "administrator password",
+            "generate": "expression",
+            "from": "[a-zA-Z0-9]{8}"
+        },
+        {
+            "name": "MYSQL_USER",
+            "description": "database username",
+            "generate": "expression",
+            "from": "user[A-Z0-9]{3}"
+        },
+        {
+            "name": "MYSQL_PASSWORD",
+            "description": "database password",
+            "generate": "expression",
+            "from": "[a-zA-Z0-9]{8}",
+            "required": true
+        },
+        {
+            "name": "MYSQL_DATABASE",
+            "description": "database name",
+            "value": "root"
+        }
+    ],
+    "labels": {
+        "template": "application-template-stibuild"
+    }
+}

--- a/src/test/resources/samples/openshift3/oapi_v1_endpoint.json
+++ b/src/test/resources/samples/openshift3/oapi_v1_endpoint.json
@@ -3,254 +3,730 @@
   "groupVersion": "v1",
   "resources": [
     {
-      "name": "buildconfigs",
+      "name": "appliedclusterresourcequotas",
+      "singularName": "",
       "namespaced": true,
-      "kind": "BuildConfig"
+      "kind": "AppliedClusterResourceQuota",
+      "verbs": [
+        "get",
+        "list"
+      ]
+    },
+    {
+      "name": "buildconfigs",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "BuildConfig",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "bc"
+      ]
     },
     {
       "name": "buildconfigs/instantiate",
+      "singularName": "",
       "namespaced": true,
-      "kind": "BuildRequest"
+      "kind": "BuildRequest",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "buildconfigs/instantiatebinary",
+      "singularName": "",
       "namespaced": true,
-      "kind": "BinaryBuildRequestOptions"
+      "kind": "BinaryBuildRequestOptions",
+      "verbs": []
     },
     {
       "name": "buildconfigs/webhooks",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Status"
+      "kind": "Build",
+      "verbs": []
     },
     {
       "name": "builds",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Build"
+      "kind": "Build",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "builds/clone",
+      "singularName": "",
       "namespaced": true,
-      "kind": "BuildRequest"
+      "kind": "BuildRequest",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "builds/details",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Build"
+      "kind": "Build",
+      "verbs": [
+        "update"
+      ]
     },
     {
       "name": "builds/log",
+      "singularName": "",
       "namespaced": true,
-      "kind": "BuildLog"
+      "kind": "BuildLog",
+      "verbs": [
+        "get"
+      ]
     },
     {
       "name": "clusternetworks",
+      "singularName": "",
       "namespaced": false,
-      "kind": "ClusterNetwork"
+      "kind": "ClusterNetwork",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
-      "name": "clusterpolicies",
+      "name": "clusterresourcequotas",
+      "singularName": "",
       "namespaced": false,
-      "kind": "ClusterPolicy"
+      "kind": "ClusterResourceQuota",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "clusterquota"
+      ]
     },
     {
-      "name": "clusterpolicybindings",
+      "name": "clusterresourcequotas/status",
+      "singularName": "",
       "namespaced": false,
-      "kind": "ClusterPolicyBinding"
+      "kind": "ClusterResourceQuota",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "clusterrolebindings",
+      "singularName": "",
       "namespaced": false,
-      "kind": "ClusterRoleBinding"
+      "kind": "ClusterRoleBinding",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "list",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "clusterroles",
+      "singularName": "",
       "namespaced": false,
-      "kind": "ClusterRole"
-    },
-    {
-      "name": "deploymentconfigrollbacks",
-      "namespaced": true,
-      "kind": "DeploymentConfigRollback"
+      "kind": "ClusterRole",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "list",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "deploymentconfigs",
+      "singularName": "",
       "namespaced": true,
-      "kind": "DeploymentConfig"
+      "kind": "DeploymentConfig",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "dc"
+      ]
+    },
+    {
+      "name": "deploymentconfigs/instantiate",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "DeploymentRequest",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "deploymentconfigs/log",
+      "singularName": "",
       "namespaced": true,
-      "kind": "DeploymentLog"
+      "kind": "DeploymentLog",
+      "verbs": [
+        "get"
+      ]
+    },
+    {
+      "name": "deploymentconfigs/rollback",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "DeploymentConfigRollback",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "deploymentconfigs/scale",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
-      "name": "generatedeploymentconfigs",
+      "name": "deploymentconfigs/status",
+      "singularName": "",
       "namespaced": true,
-      "kind": "DeploymentConfig"
+      "kind": "DeploymentConfig",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "egressnetworkpolicies",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "EgressNetworkPolicy",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "groups",
+      "singularName": "",
       "namespaced": false,
-      "kind": "Group"
+      "kind": "Group",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "hostsubnets",
+      "singularName": "",
       "namespaced": false,
-      "kind": "HostSubnet"
+      "kind": "HostSubnet",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "identities",
+      "singularName": "",
       "namespaced": false,
-      "kind": "Identity"
+      "kind": "Identity",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "images",
+      "singularName": "",
       "namespaced": false,
-      "kind": "Image"
+      "kind": "Image",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "imagesignatures",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "ImageSignature",
+      "verbs": [
+        "create",
+        "delete"
+      ]
     },
     {
       "name": "imagestreamimages",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ImageStreamImage"
+      "kind": "ImageStreamImage",
+      "verbs": [
+        "get"
+      ],
+      "shortNames": [
+        "isimage"
+      ]
     },
     {
       "name": "imagestreamimports",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ImageStreamImport"
+      "kind": "ImageStreamImport",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "imagestreammappings",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ImageStreamMapping"
+      "kind": "ImageStreamMapping",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "imagestreams",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ImageStream"
+      "kind": "ImageStream",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "is"
+      ]
     },
     {
       "name": "imagestreams/secrets",
+      "singularName": "",
       "namespaced": true,
-      "kind": "SecretList"
+      "kind": "SecretList",
+      "verbs": [
+        "get"
+      ]
     },
     {
       "name": "imagestreams/status",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ImageStream"
+      "kind": "ImageStream",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "imagestreamtags",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ImageStreamTag"
+      "kind": "ImageStreamTag",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "list",
+        "patch",
+        "update"
+      ],
+      "shortNames": [
+        "istag"
+      ]
     },
     {
       "name": "localresourceaccessreviews",
+      "singularName": "",
       "namespaced": true,
-      "kind": "LocalResourceAccessReview"
+      "kind": "LocalResourceAccessReview",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "localsubjectaccessreviews",
+      "singularName": "",
       "namespaced": true,
-      "kind": "LocalSubjectAccessReview"
+      "kind": "LocalSubjectAccessReview",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "netnamespaces",
+      "singularName": "",
       "namespaced": false,
-      "kind": "NetNamespace"
+      "kind": "NetNamespace",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "oauthaccesstokens",
+      "singularName": "",
       "namespaced": false,
-      "kind": "OAuthAccessToken"
+      "kind": "OAuthAccessToken",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "oauthauthorizetokens",
+      "singularName": "",
       "namespaced": false,
-      "kind": "OAuthAuthorizeToken"
+      "kind": "OAuthAuthorizeToken",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "oauthclientauthorizations",
+      "singularName": "",
       "namespaced": false,
-      "kind": "OAuthClientAuthorization"
+      "kind": "OAuthClientAuthorization",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "oauthclients",
+      "singularName": "",
       "namespaced": false,
-      "kind": "OAuthClient"
+      "kind": "OAuthClient",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
-      "name": "policies",
+      "name": "podsecuritypolicyreviews",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Policy"
+      "kind": "PodSecurityPolicyReview",
+      "verbs": [
+        "create"
+      ]
     },
     {
-      "name": "policybindings",
+      "name": "podsecuritypolicyselfsubjectreviews",
+      "singularName": "",
       "namespaced": true,
-      "kind": "PolicyBinding"
+      "kind": "PodSecurityPolicySelfSubjectReview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "podsecuritypolicysubjectreviews",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "PodSecurityPolicySubjectReview",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "processedtemplates",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Template"
+      "kind": "Template",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "projectrequests",
+      "singularName": "",
       "namespaced": false,
-      "kind": "ProjectRequest"
+      "kind": "ProjectRequest",
+      "verbs": [
+        "create",
+        "list"
+      ]
     },
     {
       "name": "projects",
+      "singularName": "",
       "namespaced": false,
-      "kind": "Project"
+      "kind": "Project",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "resourceaccessreviews",
+      "singularName": "",
       "namespaced": true,
-      "kind": "ResourceAccessReview"
+      "kind": "ResourceAccessReview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "rolebindingrestrictions",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "RoleBindingRestriction",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "rolebindings",
+      "singularName": "",
       "namespaced": true,
-      "kind": "RoleBinding"
+      "kind": "RoleBinding",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "list",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "roles",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Role"
+      "kind": "Role",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "list",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "routes",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Route"
+      "kind": "Route",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "routes/status",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Route"
+      "kind": "Route",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "selfsubjectrulesreviews",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "SelfSubjectRulesReview",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "subjectaccessreviews",
+      "singularName": "",
       "namespaced": true,
-      "kind": "SubjectAccessReview"
+      "kind": "SubjectAccessReview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "subjectrulesreviews",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "SubjectRulesReview",
+      "verbs": [
+        "create"
+      ]
     },
     {
       "name": "templates",
+      "singularName": "",
       "namespaced": true,
-      "kind": "Template"
+      "kind": "Template",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     },
     {
       "name": "useridentitymappings",
+      "singularName": "",
       "namespaced": false,
-      "kind": "UserIdentityMapping"
+      "kind": "UserIdentityMapping",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "patch",
+        "update"
+      ]
     },
     {
       "name": "users",
+      "singularName": "",
       "namespaced": false,
-      "kind": "User"
+      "kind": "User",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
     }
   ]
 }


### PR DESCRIPTION
- Protect /oapi loading
- Change resource version lookup algorithm

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

### Ready for review

Given the major change, it's important to have a great test matrix.

- [ ] integration tests against OCP3
- [x] integration tests against OCP4
- [ ] CodeReady Studio integration tests against OCP3
- [ ] CodeReady Studio integration tests against OCP4