### PR TITLE
handle 204 response

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/DefaultClient.java
+++ b/src/main/java/com/openshift/internal/restclient/DefaultClient.java
@@ -301,6 +301,9 @@ public class DefaultClient implements IClient, IHttpConstants {
             try (Response result = client.newCall(request).execute()) {
                 String response = result.body().string();
                 LOGGER.debug("Response: {}", response);
+                if (result.code() == 204) {
+                    return null;
+                }
                 return (T) factory.createInstanceFrom(response);
             }
         } catch (IOException e) {


### PR DESCRIPTION
DeploymentTrigger fails with NPE when server returns 204 response and empty body. This happen when DeploymentTrigger called with force=false and latest=false