### PR TITLE
use "dist: trusty" in .travis.yml to fix oraclejdk8 build (#396)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 jdk:


### PR DESCRIPTION
fixes #396 