### PR TITLE
authorize by direct request to auth-endpoint (was: using invalid bearer & authenticator indirection)

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/okhttp/OpenShiftRequestBuilder.java
+++ b/src/main/java/com/openshift/internal/restclient/okhttp/OpenShiftRequestBuilder.java
@@ -57,9 +57,9 @@ public class OpenShiftRequestBuilder {
     }
 
     public OpenShiftRequestBuilder authorization(String token) {
-        // Authenticator only gets triggered with a 401.
-        // We thus always use the token even if it's null so that we get a 401 instead of 403 in OS 4.2
-        builder.header(IHttpConstants.PROPERTY_AUTHORIZATION, IHttpConstants.AUTHORIZATION_BEARER + " " + token);
+        if (!StringUtils.isBlank(token)) {
+            builder.header(IHttpConstants.PROPERTY_AUTHORIZATION, IHttpConstants.AUTHORIZATION_BEARER + " " + token);
+        }
         return this;
     }
 


### PR DESCRIPTION
The change here is all requests hold authentication means. If those are not present an unauthenticated request to the authentication endpoint is performed in order to retrieve the bearer token. Before this fix, the request to the authentication endpoint was holding an invalid bearer token (which was ignored in 3.x but causes a Resource Forbidden Exception in CRC/OS 4.2). This causes that authentication is performed.

The bug that's reporting this issue is filed in JBoss Tools: https://issues.jboss.org/browse/JBIDE-26899
