### PR TITLE
correctly handle challenge headers with 'realm=' (#430)

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/okhttp/BasicChallengeHandler.java
+++ b/src/main/java/com/openshift/internal/restclient/okhttp/BasicChallengeHandler.java
@@ -30,8 +30,9 @@ public class BasicChallengeHandler implements IChallengeHandler {
 
     @Override
     public boolean canHandle(Headers headers) {
-        return IHttpConstants.AUTHORIZATION_BASIC
-                .equalsIgnoreCase(headers.get(IHttpConstants.PROPERTY_WWW_AUTHENTICATE));
+        String header = headers.get(IHttpConstants.PROPERTY_WWW_AUTHENTICATE);
+        return StringUtils.isNotEmpty(header)
+                && header.toLowerCase().startsWith(IHttpConstants.AUTHORIZATION_BASIC.toLowerCase());
     }
 
     @Override

--- a/src/main/java/com/openshift/restclient/http/IHttpConstants.java
+++ b/src/main/java/com/openshift/restclient/http/IHttpConstants.java
@@ -37,7 +37,7 @@ public interface IHttpConstants {
     public static final String PROPERTY_ORIGIN = "Origin";
     public static final String PROPERTY_LOCATION = "Location";
     public static final String PROPERTY_USER_AGENT = "User-Agent";
-    public static final String PROPERTY_WWW_AUTHENTICATE = "Www-Authenticate";
+    public static final String PROPERTY_WWW_AUTHENTICATE = "WWW-Authenticate";
 
     public static final String PROPERTY_AUTHKEY = "broker_auth_key";
     public static final String PROPERTY_AUTHIV = "broker_auth_iv";

--- a/src/test/java/com/openshift/internal/restclient/okhttp/BasicChallangeHandlerTest.java
+++ b/src/test/java/com/openshift/internal/restclient/okhttp/BasicChallangeHandlerTest.java
@@ -48,6 +48,7 @@ public class BasicChallangeHandlerTest {
     public void testCanHandle() {
         assertTrue(handler.canHandle(givenHeader(IHttpConstants.PROPERTY_WWW_AUTHENTICATE, "basic")));
         assertTrue(handler.canHandle(givenHeader(IHttpConstants.PROPERTY_WWW_AUTHENTICATE, "bAsIC")));
+        assertTrue(handler.canHandle(givenHeader(IHttpConstants.PROPERTY_WWW_AUTHENTICATE, "Basic realm=\"WallyWorld\"")));
         assertFalse(handler.canHandle(givenHeader(IHttpConstants.PROPERTY_WWW_AUTHENTICATE, "foobar")));
         assertFalse(handler.canHandle(givenHeader(IHttpConstants.PROPERTY_WWW_AUTHENTICATE, "")));
         assertFalse(handler.canHandle(givenHeader("key", "value")));


### PR DESCRIPTION
fixes #430 