### PR TITLE
corrected IRSyncable#Peer#toString (#437)

### DIFF
--- a/src/main/java/com/openshift/restclient/capability/resources/IRSyncable.java
+++ b/src/main/java/com/openshift/restclient/capability/resources/IRSyncable.java
@@ -164,6 +164,11 @@ public interface IRSyncable extends IBinaryCapability {
         public void append(StringBuilder commandLine) {
             commandLine.append(" ").append(getParameter());
         }
+
+        @Override
+        public String toString() {
+            return getParameter();
+        }
     }
 
     /**


### PR DESCRIPTION
fixes #437 
With this PR logging is corrected to report paths instead of java object ids:
```
Could not sync all pods to folder /Users/adietish/Documents/jboss-workspaces/jbosstools-github/runtime-openshift/.metadata/.plugins/org.jboss.ide.eclipse.as.core/jbide-25303@jboss-fuse70-java-opensh/deploy/BOOT-INF
```