### PR TITLE
Ensure null payload (on DELETE method) is transformed into empty string

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/DefaultClient.java
+++ b/src/main/java/com/openshift/internal/restclient/DefaultClient.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jboss.dmr.ModelNode;
 import org.slf4j.Logger;
@@ -339,19 +340,19 @@ public class DefaultClient implements IClient, IHttpConstants {
         return RequestBody.create(json, MediaType.parse(MEDIATYPE_APPLICATION_JSON));
     }
 
-
-    private RequestBody getPayload(InputStream payload, String method) {
+    RequestBody getPayload(InputStream payload, String method) {
         if(isPayloadlessMethod(method)) {
             return null;
         }
+        InputStream input = payload == null ? IOUtils.toInputStream("") : payload;
         LOGGER.debug("About to send binary payload");
         return new RequestBody() {
             @Override
             public void writeTo(BufferedSink sink) throws IOException {
-                Source source = Okio.source(payload);
+                Source source = Okio.source(input);
                 sink.writeAll(source);
             }
-            
+
             @Override
             public MediaType contentType() {
                 return MediaType.parse(MEDIATYPE_APPLICATION_OCTET_STREAM);

--- a/src/test/java/com/openshift/internal/restclient/DefaultClientTest.java
+++ b/src/test/java/com/openshift/internal/restclient/DefaultClientTest.java
@@ -46,6 +46,9 @@ import com.openshift.restclient.model.JSONSerializeable;
 import okhttp3.Request.Builder;
 import okhttp3.RequestBody;
 import okio.Buffer;
+import okio.BufferedSink;
+import okio.Okio;
+import okio.Source;
 
 /**
  * @author Jeff Cantrill
@@ -158,7 +161,7 @@ public class DefaultClientTest extends TypeMapperFixture {
     }
     
     @Test
-    public void should_use_paylod_in_delete_request() throws IOException {
+    public void should_use_payload_in_delete_request() throws IOException {
         // given
         DefaultClient client = spy(this.client);
 
@@ -177,7 +180,7 @@ public class DefaultClientTest extends TypeMapperFixture {
     }
 
     @Test
-    public void should_use_paylod_in_post_request() throws IOException {
+    public void should_use_payload_in_post_request() throws IOException {
         // given
         DefaultClient client = spy(this.client);
 
@@ -196,7 +199,7 @@ public class DefaultClientTest extends TypeMapperFixture {
     }
 
     @Test
-    public void should_use_paylod_in_put_request() throws IOException {
+    public void should_use_payload_in_put_request() throws IOException {
         // given
         DefaultClient client = spy(this.client);
 
@@ -215,7 +218,7 @@ public class DefaultClientTest extends TypeMapperFixture {
     }
 
     @Test
-    public void should_not_use_paylod_in_get_request() throws IOException {
+    public void should_not_use_payload_in_get_request() throws IOException {
         // given
         DefaultClient client = spy(this.client);
 
@@ -233,7 +236,7 @@ public class DefaultClientTest extends TypeMapperFixture {
     }
 
     @Test
-    public void should_not_use_paylod_in_head_request() throws IOException {
+    public void should_not_use_payload_in_head_request() throws IOException {
         // given
         DefaultClient client = spy(this.client);
 
@@ -267,6 +270,25 @@ public class DefaultClientTest extends TypeMapperFixture {
         // then
         verify(builder).method(anyString(), bodyCaptor.capture());
         assertThat(bodyCaptor.getValue().contentLength()).isEqualTo(0);        
+    }
+
+    @Test
+    public void should_transform_input_to_empty_string_when_payload_is_null() throws IOException {
+        // given
+        DefaultClient client = spy(this.client);
+        RequestBody payload = client.getPayload(null, HttpMethod.DELETE.name());
+
+        BufferedSink bufferedSink = mock(BufferedSink.class);
+        ArgumentCaptor<Source> bodyCaptor = ArgumentCaptor.forClass(Source.class);
+
+        // when
+        payload.writeTo(bufferedSink);
+
+        // then
+        verify(bufferedSink).writeAll(bodyCaptor.capture());
+        String actualPayload = Okio.buffer(bodyCaptor.getValue()).readUtf8();
+
+        assertThat(actualPayload).isEqualTo("");
     }
 
     private String getPayload(Builder builder, ArgumentCaptor<RequestBody> builderCaptor) throws IOException {


### PR DESCRIPTION
This is the code change to fix issues [454](https://github.com/openshift/openshift-restclient-java/issues/454)

**What's changed**
- There will be a check if the payload used by `client.execute()` containing null values for `InputStream` parameter.
- Refactoring typo in the test
- Access modifier for `DefaultClient.getPayload()` changed to default to be accessible by the test