### PR TITLE
Updage log4j libraries to 2.17.1 to fix CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <version.shrinkwrap_resolver>1.0.0-beta-5</version.shrinkwrap_resolver>
         <version.shrinkwrap_descriptors>1.1.0-beta-1</version.shrinkwrap_descriptors>
 		<version.slf4j>2.0.0-alpha1</version.slf4j>
-		<version.log4j>2.13.0</version.log4j>
+		<version.log4j>2.17.1</version.log4j>
 
         <!-- integration test properties file -->
         <integrationtest.properties>${basedir}/src/test/resources/openshiftv3IntegrationTest.properties</integrationtest.properties>


### PR DESCRIPTION
Signed-off-by: Ondrej Dockal <odockal@redhat.com>