### PR TITLE
Refactor: Refactoring code

### DIFF
--- a/src/main/java/com/openshift/internal/restclient/ApiTypeMapper.java
+++ b/src/main/java/com/openshift/internal/restclient/ApiTypeMapper.java
@@ -189,8 +189,9 @@ public class ApiTypeMapper implements IApiTypeMapper, ResourcePropertyKeys {
         VersionedApiResource resource = new VersionedApiResource(prefix, apiGroupName, version, name, kind, namespaced);
         VersionedType type = new VersionedType(prefix, typeApiGroupName != null ? typeApiGroupName : apiGroupName,
                 typeVersion != null ? typeVersion : version, kind);
-        if (capability == null && node.has(VERBS) && !node.get(VERBS).asList().isEmpty()
-                && !endpoints.contains(resource)) {
+        boolean hasVerbs = node.has(VERBS) && !node.get(VERBS).asList().isEmpty();
+        boolean isNotEndpoint = !endpoints.contains(resource);
+        if (capability == null && hasVerbs && isNotEndpoint){
             endpoints.add(resource);
         }
         if (!types.contains(type)) {

--- a/src/main/java/com/openshift/internal/restclient/model/ServiceAccount.java
+++ b/src/main/java/com/openshift/internal/restclient/model/ServiceAccount.java
@@ -18,6 +18,7 @@ import org.jboss.dmr.ModelType;
 
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.model.serviceaccount.IServiceAccount;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @author David Simansky | dsimansk@redhat.com
@@ -33,8 +34,13 @@ public class ServiceAccount extends KubernetesResource implements IServiceAccoun
 
     @Override
     public Collection<String> getSecrets() {
+        return getServiceAccountSecrets(SERVICE_ACCOUNT_SECRETS);
+    }
+
+    @NotNull
+    private Collection<String> getServiceAccountSecrets(String serviceAccountSecrets) {
         Collection<String> secrets = new ArrayList<>();
-        ModelNode node = get(SERVICE_ACCOUNT_SECRETS);
+        ModelNode node = get(serviceAccountSecrets);
         if (node.getType() != ModelType.LIST) {
             return secrets;
         }
@@ -52,15 +58,7 @@ public class ServiceAccount extends KubernetesResource implements IServiceAccoun
 
     @Override
     public Collection<String> getImagePullSecrets() {
-        Collection<String> secrets = new ArrayList<>();
-        ModelNode node = get(SERVICE_ACCOUNT_IMAGE_PULL_SECRETS);
-        if (node.getType() != ModelType.LIST) {
-            return secrets;
-        }
-        for (ModelNode entry : node.asList()) {
-            secrets.add(asString(entry, NAME));
-        }
-        return secrets;
+        return getServiceAccountSecrets(SERVICE_ACCOUNT_IMAGE_PULL_SECRETS);
     }
 
     @Override

--- a/src/main/java/com/openshift/internal/restclient/model/build/EnvVars.java
+++ b/src/main/java/com/openshift/internal/restclient/model/build/EnvVars.java
@@ -1,0 +1,21 @@
+package com.openshift.internal.restclient.model.build;
+
+import com.openshift.internal.restclient.model.EnvironmentVariable;
+import com.openshift.restclient.model.IEnvironmentVariable;
+import org.jboss.dmr.ModelNode;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class EnvVars {
+    public Collection<IEnvironmentVariable> getEnvVars(String[] path, ModelNode node, Map<String, String[]> propertyKeys){
+        ModelNode envNode = node.get(path);
+        if (envNode.isDefined()) {
+            return envNode.asList().stream().map(n -> new EnvironmentVariable(n, propertyKeys))
+                    .collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/openshift/internal/restclient/model/build/JenkinsPipelineStrategy.java
+++ b/src/main/java/com/openshift/internal/restclient/model/build/JenkinsPipelineStrategy.java
@@ -68,12 +68,10 @@ public class JenkinsPipelineStrategy extends ModelNodeAdapter
     @Override
     public Collection<IEnvironmentVariable> getEnvVars() {
         String[] path = JBossDmrExtentions.getPath(getPropertyKeys(), ENV);
-        ModelNode envNode = getNode().get(path);
-        if (envNode.isDefined()) {
-            return envNode.asList().stream().map(n -> new EnvironmentVariable(n, getPropertyKeys()))
-                    .collect(Collectors.toList());
-        }
-        return Collections.emptyList();
+        ModelNode envNode = getNode();
+        Map<String, String[]> propertyKeys = getPropertyKeys();
+        EnvVars env = new EnvVars();
+        return env.getEnvVars(path, envNode, propertyKeys);
     }
 
     @Override

--- a/src/main/java/com/openshift/restclient/model/build/GetEnvSuper.java
+++ b/src/main/java/com/openshift/restclient/model/build/GetEnvSuper.java
@@ -1,0 +1,10 @@
+package com.openshift.restclient.model.build;
+
+import com.openshift.restclient.model.IEnvironmentVariable;
+
+import java.util.Collection;
+
+public interface GetEnvSuper {
+
+    Collection<IEnvironmentVariable> getEnvVars();
+}

--- a/src/main/java/com/openshift/restclient/model/build/IBuildSourceHandler.java
+++ b/src/main/java/com/openshift/restclient/model/build/IBuildSourceHandler.java
@@ -1,0 +1,5 @@
+package com.openshift.restclient.model.build;
+
+public interface IBuildSourceHandler {
+    void setProperties(IBuildSource source);
+}

--- a/src/main/java/com/openshift/restclient/model/build/IJenkinsPipelineStrategy.java
+++ b/src/main/java/com/openshift/restclient/model/build/IJenkinsPipelineStrategy.java
@@ -16,7 +16,7 @@ import com.openshift.restclient.model.IEnvironmentVariable;
 /**
  * @author Andre Dietisheim
  */
-public interface IJenkinsPipelineStrategy extends IBuildStrategy {
+public interface IJenkinsPipelineStrategy extends IBuildStrategy, GetEnvSuper {
 
     static final String JENKINS_FILE = "jenkinsPipelineStrategy.jenkinsfile";
     static final String JENKINS_FILE_PATH = "jenkinsPipelineStrategy.jenkinsfilePath";
@@ -29,8 +29,6 @@ public interface IJenkinsPipelineStrategy extends IBuildStrategy {
     void setJenkinsfile(String jenkinsFile);
 
     String getJenkinsfile();
-
-    Collection<IEnvironmentVariable> getEnvVars();
 
     void setEnvVars(Collection<IEnvironmentVariable> envVars);
 }

--- a/src/main/java/com/openshift/restclient/model/build/ISourceBuildStrategy.java
+++ b/src/main/java/com/openshift/restclient/model/build/ISourceBuildStrategy.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import com.openshift.restclient.images.DockerImageURI;
 import com.openshift.restclient.model.IEnvironmentVariable;
 
-public interface ISourceBuildStrategy extends IBuildStrategy {
+public interface ISourceBuildStrategy extends IBuildStrategy, GetEnvSuper {
 
     /**
      * Returns the Builder Image used to execute the build
@@ -41,8 +41,6 @@ public interface ISourceBuildStrategy extends IBuildStrategy {
     Map<String, String> getEnvironmentVariables();
 
     void setEnvironmentVariables(Map<String, String> envVars);
-
-    Collection<IEnvironmentVariable> getEnvVars();
 
     /**
      * Setting using a null collection will early return without modification to the


### PR DESCRIPTION
1. GetEnvSuper.java : Both the interfaces ISourceBuildStrategy and IJenkinsPipelineStrategy had the same method getEnvVars(), so I created a new interface and implemented that directly where getEnvVars() was used.
2. SourceBuilderStrategy.java : Renamed the variable to avoide confusion with reserved keyword "var".
3. SourceBuilderStrategy.java and JenkinsPipelineStrategy : Both the method had exactly same method implementaion, so created a new class with the method that can be reused.
4. ApiTypeMapper : Decomposed the condition to make it more readable and maintainable.
5. ServiceAccount.java : Two methods had exactly same implementation so extracted the method to avoide duplication of code. 